### PR TITLE
Feature/add archunit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.tngtech.archunit:archunit-junit5:1.1.0'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/example/demo/archunit/LayeredArchitectureTest.java
+++ b/src/test/java/com/example/demo/archunit/LayeredArchitectureTest.java
@@ -1,0 +1,20 @@
+package com.example.demo.archunit;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
+
+@AnalyzeClasses(packages = "com.example.demo")
+public class LayeredArchitectureTest {
+
+    @ArchTest
+    static final ArchRule layer_dependencies_are_respected = layeredArchitecture().consideringAllDependencies()
+        .layer("Controllers").definedBy("com.example.demo.web.v1..")
+        .layer("Services").definedBy("com.example.demo.core..service..")
+        .layer("Persistence").definedBy("com.example.demo.infrastructure.persistence..")
+        .whereLayer("Controllers").mayNotBeAccessedByAnyLayer()
+        .whereLayer("Services").mayOnlyBeAccessedByLayers("Controllers")
+        .whereLayer("Persistence").mayOnlyBeAccessedByLayers("Services");
+}

--- a/src/test/java/com/example/demo/archunit/NamingConventionTest.java
+++ b/src/test/java/com/example/demo/archunit/NamingConventionTest.java
@@ -1,0 +1,27 @@
+package com.example.demo.archunit;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+@AnalyzeClasses(packages = "com.example.demo")
+public class NamingConventionTest {
+
+    @ArchTest
+    static ArchRule controllers_should_be_suffixed =
+        classes()
+            .that().resideInAPackage("..web..")
+            .and().areAnnotatedWith(RestController.class)
+            .should().haveSimpleNameEndingWith("Controller");
+
+    @ArchTest
+    static ArchRule services_should_be_suffixed =
+        classes()
+            .that().resideInAPackage("..service..")
+            .and().areAnnotatedWith(Service.class)
+            .should().haveSimpleNameEndingWith("Service");
+}


### PR DESCRIPTION
ArchUnit 디펜던시를 추가하여 피트니스 함수 정의

프로젝트의 패키지 의존성 검증
클래스별 네이밍 규칙 검증

https://github.com/TNG/ArchUnit

의존성 및 네이밍 규칙 검증에 실패하면 테스트 실패 발생
infrastructure.persistence 패키지에 있는 TestClass가 service 패키지의 CreateOrderService를 의존하여 테스트 실패
```
Constructor <com.example.demo.infrastructure.persistence.member.TestClass.<init>(com.example.demo.core.order.service.CreateOrderService)> has parameter of type <com.example.demo.core.order.service.CreateOrderService> in (TestClass.java:0)
Field <com.example.demo.infrastructure.persistence.member.TestClass.createOrderService> has type <com.example.demo.core.order.service.CreateOrderService> in (TestClass.java:0)
```