### PR TITLE
Feature/false dirty flushing

### DIFF
--- a/src/main/java/com/example/demo/core/member/domain/Member.java
+++ b/src/main/java/com/example/demo/core/member/domain/Member.java
@@ -1,6 +1,8 @@
 package com.example.demo.core.member.domain;
 
 import com.example.demo.config.persistence.AuditEntity;
+import com.example.demo.infrastructure.persistence.member.MemberNickName1;
+import com.example.demo.infrastructure.persistence.member.MemberNickName2;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -27,11 +29,19 @@ public class Member extends AuditEntity {
     @Column(name = "member_name", nullable = false, updatable = false)
     private String memberName;
 
+    @Column(name = "member_nickname_1", columnDefinition = "VARCHAR(64)")
+    private MemberNickName1 memberNickName1;
+
+    @Column(name = "member_nickname_2", columnDefinition = "VARCHAR(64)")
+    private MemberNickName2 memberNickName2;
+
     public Member(
         String memberId,
         String memberName
     ) {
         this.memberId = memberId;
         this.memberName = memberName;
+        this.memberNickName1 = new MemberNickName1(memberName);
+        this.memberNickName2 = new MemberNickName2(memberName);
     }
 }

--- a/src/main/java/com/example/demo/core/member/domain/Member.java
+++ b/src/main/java/com/example/demo/core/member/domain/Member.java
@@ -12,8 +12,10 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Getter
+@DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "member")

--- a/src/main/java/com/example/demo/infrastructure/persistence/member/MemberNickName1.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/member/MemberNickName1.java
@@ -1,0 +1,12 @@
+package com.example.demo.infrastructure.persistence.member;
+
+import lombok.Getter;
+
+@Getter
+public class MemberNickName1 {
+    private final String value;
+
+    public MemberNickName1(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/example/demo/infrastructure/persistence/member/MemberNickName1Converter.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/member/MemberNickName1Converter.java
@@ -1,0 +1,17 @@
+package com.example.demo.infrastructure.persistence.member;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class MemberNickName1Converter implements AttributeConverter<MemberNickName1, String> {
+    @Override
+    public String convertToDatabaseColumn(MemberNickName1 memberNickName) {
+        return memberNickName == null ? null : memberNickName.getValue().toLowerCase();
+    }
+
+    @Override
+    public MemberNickName1 convertToEntityAttribute(String s) {
+        return s == null ? null : new MemberNickName1(s);
+    }
+}

--- a/src/main/java/com/example/demo/infrastructure/persistence/member/MemberNickName2.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/member/MemberNickName2.java
@@ -1,0 +1,27 @@
+package com.example.demo.infrastructure.persistence.member;
+
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+public class MemberNickName2 {
+    private final String value;
+
+    public MemberNickName2(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MemberNickName2 that = (MemberNickName2) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+}

--- a/src/main/java/com/example/demo/infrastructure/persistence/member/MemberNickName2Converter.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/member/MemberNickName2Converter.java
@@ -1,0 +1,17 @@
+package com.example.demo.infrastructure.persistence.member;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class MemberNickName2Converter implements AttributeConverter<MemberNickName2, String> {
+    @Override
+    public String convertToDatabaseColumn(MemberNickName2 memberNickName) {
+        return memberNickName == null ? null : memberNickName.getValue().toLowerCase();
+    }
+
+    @Override
+    public MemberNickName2 convertToEntityAttribute(String s) {
+        return s == null ? null : new MemberNickName2(s);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,11 +10,11 @@ spring:
     username: sa
     password:
   jpa:
+    show-sql: true
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
-        show_sql: true
         format_sql: true
         order_inserts: true
         order_updates: true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,16 +15,9 @@ spring:
       ddl-auto: create
     properties:
       hibernate:
-        format-sql: true
-        show-sql: true
-    open-in-view: false
     database-platform: org.hibernate.dialect.H2Dialect
     defer-datasource-initialization: false
 
 logging:
   level:
-    org.hibernate.SQL: DEBUG
-    org.hibernate.type: TRACE
-    org.springframework.orm.jpa: DEBUG
-    org.springframework.transaction: DEBUG
-    org.springframework.jdbc: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE


### PR DESCRIPTION
`@Converter`로 인한 dirty check 발생 테스트

`@Converter`로 인해 예상치 못 한 update 쿼리가 발생하여 장애가 났다는 얘기를 들음
작업을 하다보면 DB 데이터를 JPA 엔티티로 가져올 때, `@Converter`로 VARCHAR 컬럼 String 데이터를 List, Object 데이터로 변환하는 경우가 많아서 다시 확인하기 위한 PR

<img width="601" alt="스크린샷 2024-11-08 오후 3 55 27" src="https://github.com/user-attachments/assets/3d73f25f-ae3c-46a9-98d0-ab53af0c3770">

조회만 했을 뿐인데, Select 쿼리 이후에 Update 쿼리 발생

결론:
`@Converter`로 값에서 객체로 변환 시 equals() 구현을 고려해야 함
equals()를 구현하지 않으면, 객체로 비교하기 때문에 dirty check (update)가 발생

데이터 조회 시 `@Transactional`과 `@Transactional(readOnly = true)`를 구분해서 사용해야 함
`@Transactional`은 의도치 않은 dirty check가 발생할 수 있음
master, slave DB 구조에서 DynamicRoutingDataSource 사용 시 반드시 master에서 조회가 필요하다면 `@Transactional` 사용을 감수해야할 듯

이번 작업을 하면서 `@Column(updatable = false)`과 `@DynamicUpdate`를 다시 생각하는 계기가 되었음
업데이트 쿼리 로그의 set 절에 memberNickName1 만 존재하기를 기대했는데, memberNickName1과 memberNickName2가 같이 존재해서 equals()가 오작동하는 것으로 오해함

원인은 memberNickName2에 `@Column(updatable = false)`가 없어서 memberNickName1가 dirty check 되면서 memberNickName2까지 업데이트 쿼리문에 추가된 것.
(업데이트 쿼리문에 추가될 뿐 memberNickName2 값은 동일)

업데이트가 안되는 컬럼은 반드시 `@Column(updatable = false)` 선언해줘야한다는 것을 다시 한번 느끼게 됨.
`@DynamicUpdate`는 경우에 따라 다를 것 같은데, 데이터 업데이트에 보수 적인 엔티티(테이블)에는 적용해볼법할 듯.

https://medium.com/@paul.klingelhuber/hibernate-dirty-checking-with-converted-attributes-1b6d1cd27f68
https://jojoldu.tistory.com/536