### PR TITLE
Feature/jpa inheritance

### DIFF
--- a/src/main/java/com/example/demo/common/enums/product/ProductType.java
+++ b/src/main/java/com/example/demo/common/enums/product/ProductType.java
@@ -1,0 +1,12 @@
+package com.example.demo.common.enums.product;
+
+import lombok.Getter;
+
+@Getter
+public enum ProductType {
+    FOOD;
+
+    public static class Values {
+        public static final String FOOD = "FOOD";
+    }
+}

--- a/src/main/java/com/example/demo/common/enums/product/ProductType.java
+++ b/src/main/java/com/example/demo/common/enums/product/ProductType.java
@@ -4,9 +4,10 @@ import lombok.Getter;
 
 @Getter
 public enum ProductType {
-    FOOD;
+    FOOD, ELECTRONIC;
 
     public static class Values {
         public static final String FOOD = "FOOD";
+        public static final String ELECTRONIC = "ELECTRONIC";
     }
 }

--- a/src/main/java/com/example/demo/common/enums/product/VoltType.java
+++ b/src/main/java/com/example/demo/common/enums/product/VoltType.java
@@ -1,0 +1,5 @@
+package com.example.demo.common.enums.product;
+
+public enum VoltType {
+    V220, V110
+}

--- a/src/main/java/com/example/demo/core/product/domain/ElectronicProduct.java
+++ b/src/main/java/com/example/demo/core/product/domain/ElectronicProduct.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 public class ElectronicProduct extends Product {
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "volt_type", nullable = false)
+    @Column(name = "volt_type")
     private VoltType voltType;
 
     public ElectronicProduct(final String productCode,

--- a/src/main/java/com/example/demo/core/product/domain/ElectronicProduct.java
+++ b/src/main/java/com/example/demo/core/product/domain/ElectronicProduct.java
@@ -1,0 +1,35 @@
+package com.example.demo.core.product.domain;
+
+import com.example.demo.common.enums.product.ProductStatus;
+import com.example.demo.common.enums.product.ProductType;
+import com.example.demo.common.enums.product.VoltType;
+import com.example.demo.core.stock.domain.Stock;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@DiscriminatorValue(ProductType.Values.ELECTRONIC)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ElectronicProduct extends Product {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "volt_type", nullable = false)
+    private VoltType voltType;
+
+    public ElectronicProduct(final String productCode,
+                             final String productName,
+                             final ProductStatus productStatus,
+                             final long productAmount,
+                             final Stock stock,
+                             final VoltType voltType) {
+        super(productCode, productName, productStatus, productAmount, stock);
+        this.voltType = voltType;
+    }
+}

--- a/src/main/java/com/example/demo/core/product/domain/FoodProduct.java
+++ b/src/main/java/com/example/demo/core/product/domain/FoodProduct.java
@@ -1,0 +1,33 @@
+package com.example.demo.core.product.domain;
+
+import com.example.demo.common.enums.product.ProductStatus;
+import com.example.demo.common.enums.product.ProductType;
+import com.example.demo.core.stock.domain.Stock;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@DiscriminatorValue(ProductType.Values.FOOD)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FoodProduct extends Product {
+
+    @Column(name = "expiration_date", nullable = false)
+    private LocalDate expirationDate;
+
+    public FoodProduct(final String productCode,
+                       final String productName,
+                       final ProductStatus productStatus,
+                       final long productAmount,
+                       final Stock stock,
+                       final LocalDate expirationDate) {
+        super(productCode, productName, productStatus, productAmount, stock);
+        this.expirationDate = expirationDate;
+    }
+}

--- a/src/main/java/com/example/demo/core/product/domain/FoodProduct.java
+++ b/src/main/java/com/example/demo/core/product/domain/FoodProduct.java
@@ -18,7 +18,7 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FoodProduct extends Product {
 
-    @Column(name = "expiration_date", nullable = false)
+    @Column(name = "expiration_date")
     private LocalDate expirationDate;
 
     public FoodProduct(final String productCode,

--- a/src/main/java/com/example/demo/core/product/domain/Product.java
+++ b/src/main/java/com/example/demo/core/product/domain/Product.java
@@ -6,6 +6,7 @@ import com.example.demo.common.exceptions.BusinessException;
 import com.example.demo.config.persistence.AuditEntity;
 import com.example.demo.core.stock.domain.Stock;
 import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -13,6 +14,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
@@ -21,10 +24,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "product")
-public class Product extends AuditEntity {
+@DiscriminatorColumn(name = "product_type")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+public abstract class Product extends AuditEntity {
     @Id
     @Column(name = "product_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,13 +52,11 @@ public class Product extends AuditEntity {
     @JoinColumn(name = "stock_id", referencedColumnName = "stock_id", nullable = false, updatable = false)
     private Stock stock;
 
-    public Product(
-        String productCode,
-        String productName,
-        ProductStatus productStatus,
-        long productAmount,
-        Stock stock
-    ) {
+    public Product(final String productCode,
+                   final String productName,
+                   final ProductStatus productStatus,
+                   final long productAmount,
+                   final Stock stock) {
         this.productCode = productCode;
         this.productName = productName;
         this.productStatus = productStatus;

--- a/src/main/java/com/example/demo/core/product/param/CreateProductParam.java
+++ b/src/main/java/com/example/demo/core/product/param/CreateProductParam.java
@@ -1,9 +1,12 @@
 package com.example.demo.core.product.param;
 
 import com.example.demo.common.enums.product.ProductStatus;
+import com.example.demo.core.product.domain.FoodProduct;
 import com.example.demo.core.product.domain.Product;
 import com.example.demo.core.stock.domain.Stock;
 import lombok.Getter;
+
+import java.time.LocalDate;
 
 @Getter
 public class CreateProductParam {
@@ -33,12 +36,13 @@ public class CreateProductParam {
     }
 
     public Product toProductEntity(Stock stock) {
-        return new Product(
+        return new FoodProduct(
             productCode,
             productName,
             ProductStatus.READY,
             productAmount,
-            stock
+            stock,
+            LocalDate.now()
         );
     }
 }

--- a/src/test/java/com/example/demo/core/product/service/SearchProductServiceTest.java
+++ b/src/test/java/com/example/demo/core/product/service/SearchProductServiceTest.java
@@ -3,7 +3,7 @@ package com.example.demo.core.product.service;
 import com.example.demo.TestDataInsertSupport;
 import com.example.demo.annotation.IntegrationTest;
 import com.example.demo.common.enums.product.ProductStatus;
-import com.example.demo.core.product.domain.Product;
+import com.example.demo.core.product.domain.FoodProduct;
 import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.product.param.SearchProductParam;
 import com.example.demo.core.product.result.SearchProductResult;
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
 
 import static com.example.demo.ProductFixtures.PRODUCT_NAME;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -48,7 +50,7 @@ class SearchProductServiceTest extends TestDataInsertSupport {
         void setUp() {
             final Stock stock = new Stock("A202307300134", 10_000, 0);
             save(stock);
-            save(new Product("A202307300134", PRODUCT_NAME, ProductStatus.SELLING, maxProductAmount, stock));
+            save(new FoodProduct("A202307300134", PRODUCT_NAME, ProductStatus.SELLING, maxProductAmount, stock, LocalDate.now()));
         }
 
         @Nested

--- a/src/test/java/com/example/demo/core/product/service/SellProductServiceTest.java
+++ b/src/test/java/com/example/demo/core/product/service/SellProductServiceTest.java
@@ -4,6 +4,7 @@ import com.example.demo.TestDataInsertSupport;
 import com.example.demo.annotation.IntegrationTest;
 import com.example.demo.common.exceptions.BusinessErrorCode;
 import com.example.demo.common.exceptions.BusinessException;
+import com.example.demo.core.product.domain.FoodProduct;
 import com.example.demo.core.product.domain.Product;
 import com.example.demo.core.product.result.FindProductResult;
 import com.example.demo.core.stock.domain.Stock;
@@ -15,6 +16,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
 
 import static com.example.demo.ProductFixtures.PRODUCT_CODE;
 import static com.example.demo.ProductFixtures.PRODUCT_NAME;
@@ -76,7 +79,7 @@ class SellProductServiceTest extends TestDataInsertSupport {
                 void setUp () {
                     final Stock stock = new Stock(productCode, 0, 0);
                     save(stock);
-                    save(new Product(productCode, PRODUCT_NAME, SOLD_OUT, 100, stock));
+                    save(new FoodProduct(productCode, PRODUCT_NAME, SOLD_OUT, 100, stock, LocalDate.now()));
                 }
 
                 @Test
@@ -103,7 +106,7 @@ class SellProductServiceTest extends TestDataInsertSupport {
                 void setUp () {
                     final Stock stock = new Stock(productCode, 10, 10);
                     save(stock);
-                    save(new Product(productCode, PRODUCT_NAME, SOLD_OUT, 100, stock));
+                    save(new FoodProduct(productCode, PRODUCT_NAME, SOLD_OUT, 100, stock, LocalDate.now()));
                 }
 
                 @Test
@@ -130,7 +133,7 @@ class SellProductServiceTest extends TestDataInsertSupport {
                 void setUp () {
                     final Stock stock = new Stock(productCode, 100, 10);
                     save(stock);
-                    save(new Product(productCode, PRODUCT_NAME, SOLD_OUT, 100, stock));
+                    save(new FoodProduct(productCode, PRODUCT_NAME, SOLD_OUT, 100, stock, LocalDate.now()));
                 }
 
                 @Test

--- a/src/test/java/com/example/demo/core/product/service/SoldOutProductServiceTest.java
+++ b/src/test/java/com/example/demo/core/product/service/SoldOutProductServiceTest.java
@@ -5,9 +5,10 @@ import com.example.demo.annotation.IntegrationTest;
 import com.example.demo.common.enums.product.ProductStatus;
 import com.example.demo.common.exceptions.BusinessErrorCode;
 import com.example.demo.common.exceptions.BusinessException;
+import com.example.demo.core.product.domain.FoodProduct;
 import com.example.demo.core.product.domain.Product;
-import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.product.result.FindProductResult;
+import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.infrastructure.persistence.product.ProductRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
 
 import static com.example.demo.ProductFixtures.PRODUCT_CODE;
 import static com.example.demo.ProductFixtures.PRODUCT_NAME;
@@ -71,7 +74,7 @@ class SoldOutProductServiceTest extends TestDataInsertSupport {
                 void setUp () {
                     final Stock stock = new Stock(productCode, 10_000, 0);
                     save(stock);
-                    save(new Product(productCode, PRODUCT_NAME, ProductStatus.SELLING, 100, stock));
+                    save(new FoodProduct(productCode, PRODUCT_NAME, ProductStatus.SELLING, 100, stock, LocalDate.now()));
                 }
 
                 @Test
@@ -96,7 +99,7 @@ class SoldOutProductServiceTest extends TestDataInsertSupport {
                 void setUp () {
                     final Stock stock = new Stock(productCode, 10_000, 0);
                     save(stock);
-                    save(new Product(productCode, PRODUCT_NAME, ProductStatus.END, 100, stock));
+                    save(new FoodProduct(productCode, PRODUCT_NAME, ProductStatus.END, 100, stock, LocalDate.now()));
                 }
 
                 @Test

--- a/src/test/java/com/example/demo/infrastructure/persistence/product/ProductCustomRepositoryImplTest.java
+++ b/src/test/java/com/example/demo/infrastructure/persistence/product/ProductCustomRepositoryImplTest.java
@@ -3,6 +3,7 @@ package com.example.demo.infrastructure.persistence.product;
 import com.example.demo.TestDataInsertSupport;
 import com.example.demo.annotation.RepositoryTest;
 import com.example.demo.common.enums.product.ProductStatus;
+import com.example.demo.core.product.domain.FoodProduct;
 import com.example.demo.core.product.domain.Product;
 import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.product.param.SearchProductParam;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.example.demo.ProductFixtures.PRODUCT_NAME;
@@ -52,10 +54,10 @@ class ProductCustomRepositoryImplTest extends TestDataInsertSupport {
             saveAll(stocks);
 
             final List<Product> products = List.of(
-                new Product("A202307300134", PRODUCT_NAME, ProductStatus.SELLING, maxProductAmount, stocks.get(0)),
-                new Product("A202307300135", "깐풍기", ProductStatus.READY, minProductAmount, stocks.get(1)),
-                new Product("A202307300136", "선풍기", ProductStatus.SELLING, 3000, stocks.get(2)),
-                new Product("A202307300137", "냉장고", ProductStatus.SELLING, 50_000, stocks.get(3))
+                new FoodProduct("A202307300134", PRODUCT_NAME, ProductStatus.SELLING, maxProductAmount, stocks.get(0), LocalDate.now()),
+                new FoodProduct("A202307300135", "깐풍기", ProductStatus.READY, minProductAmount, stocks.get(1), LocalDate.now()),
+                new FoodProduct("A202307300136", "선풍기", ProductStatus.SELLING, 3000, stocks.get(2), LocalDate.now()),
+                new FoodProduct("A202307300137", "냉장고", ProductStatus.SELLING, 50_000, stocks.get(3), LocalDate.now())
             );
             saveAll(products);
         }


### PR DESCRIPTION
Jpa Entitiy의 `@Inheritance(strategy = InheritanceType.SINGLE_TABLE)`을 적용해본 PR

기존에 Jpa Entity를 사용하면서 느낀 아쉬운 점은 테이블과 어플리케이션(서비스 레이어)에서 사용하는 엔티티간 차이가 벌어지는 점이었음
예를 들어 상품 테이블에 음식, 전자기기, 음악 등등의 다양한 개념이 추가됨에 따라 nullable 컬럼(필드)이 추가되고, 서비스 레이어에 그대로 영향이 가기 때문.
그래서 개인적으로 Jpa와 도메인 엔티티를 분리하는 방향을 선호했음

최근에 `@Inheritance` 존재를 알게 되었고, 어떤 구조인지 알고 싶어 테스트 삼아 작업해봄
`@Inheritance` 전략에는 3가지가 있는데, `InheritanceType.SINGLE_TABLE`로 적용해봄
product 단일 테이블 기준으로 FoodProduct와 ElectronicProduct 2개의 Jpa 엔티티로 분리하고, FoodProduct에는 expiration_date (유통기한) 필드를, ElectronicProduct에는 volt_type (전압 타입) 필드를 추가

테스트 코드 실행 시 product ddl에 expiration_date와 volt_type이 포함된 create 문이 실행 됨
그리고 FoodProduct와 ElectronicProduct를 구분하는 product_type (default: DTYPE) 컬럼이 자동으로 추가 됨
```
create table product (
        expiration_date date,
        created_at timestamp(6) not null,
        product_amount bigint not null,
        product_id bigint generated by default as identity,
        stock_id bigint not null unique,
        updated_at timestamp(6) not null,
        product_type varchar(31) not null,
        created_by varchar(255) not null,
        product_code varchar(255) not null unique,
        product_name varchar(255) not null,
        updated_by varchar(255) not null,
        product_status enum ('END','READY','SELLING','SOLD_OUT') not null,
        volt_type enum ('V110','V220'),
        primary key (product_id)
    )
```

단일 테이블에서 2개 이상의 Jpa Entity를 운영할 수 있어서 도메인 엔티티 운영 비용을 줄일 수 있었음
초기 프로젝트 구성에서는 사용할만한 것 같음

반면에 단점이 더 많다고 느껴져서 여전히 도메인 엔티티를 사용하는게 좋다고 생각 됨
물론, 아직 맛보기 단계라서 다양한 설정들과 활용 방법을 더 찾아봐야함

1. product_type (DTYPE) 컬럼을 제어할 수 없음
처음 시도했던건 Member 테이블을 활성회원과 휴면회원으로 분리하는 것이었고, DTYPE 컬럼을 값을 유동적으로 변경할 수 있는 일종의 `member_status` 상태 값처럼 사용하고 싶었음
Member Jpa Entity에 `@Column(member_status) memberStatus` 필드를 추가하면 중복 컬럼이 존재한다고 익셉션이 발생
그래서 어플리케이션 로직에서 memberStatus 필드를 제어할 수 가 없었음.

DTYPE 필드를 제어할 수 없기 때문에 유동적으로 변경되는 상태보다 데이터가 생성되면 절대 변경되지 않는 개념이어야 했고, 본 PR처럼 상품 종류로 작업하게 되었음
DTYPE 필드를 제어할 수 없다는건 최상위 Product 개념으로 전체 조회가 불가능함
FoodProduct와 ElectronicProduct를 각각 조회할 수 밖에 없는 듯


2. nullable 필드(컬럼)
이게 가장 크리티컬하다고 생각되었음
도메인 엔티티를 사용한다는건 서비스 레이어에서 필요한 필드(컬럼)만 추출하고, not null을 보장하여 로직의 안정성을 높이기 위함이라고 생각함
`@Inheritance` 사용하면 자식 엔티티(FoodProduct)에서 `@Column(nullable = false)`를 선언할 수 있지만, 다른 자식 엔티티(ElectronicProduct)를 제어할 때 익셉션이 발생함
ElectronicProduct에서 expiration_date(유통기한) 값이 nullable 일 수 밖에 없기 때문에 익셉션이 발생할 수 밖에 없는건 납득하였고, `nullable = false`를 사용할 수 없다는 점에는 동의함
하지만 이렇게 된다면 사실 상 FoodProduct Jpa Entity에서도 expiration_date(유통기한) 값이 not null이라고 보장하기 어려워보임
Java에서는 그려려니해도 null safety 언어인 Kotlin에서는 지옥이 펼쳐지는 것

