### PR TITLE
아크유닛 레이어 아키텍처 검증 실패 수정

### DIFF
--- a/src/main/java/com/example/demo/core/member/domain/Member.java
+++ b/src/main/java/com/example/demo/core/member/domain/Member.java
@@ -1,8 +1,6 @@
 package com.example.demo.core.member.domain;
 
 import com.example.demo.config.persistence.AuditEntity;
-import com.example.demo.infrastructure.persistence.member.MemberNickName1;
-import com.example.demo.infrastructure.persistence.member.MemberNickName2;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/example/demo/core/member/domain/MemberNickName1.java
+++ b/src/main/java/com/example/demo/core/member/domain/MemberNickName1.java
@@ -1,4 +1,4 @@
-package com.example.demo.infrastructure.persistence.member;
+package com.example.demo.core.member.domain;
 
 import lombok.Getter;
 

--- a/src/main/java/com/example/demo/core/member/domain/MemberNickName1Converter.java
+++ b/src/main/java/com/example/demo/core/member/domain/MemberNickName1Converter.java
@@ -1,4 +1,4 @@
-package com.example.demo.infrastructure.persistence.member;
+package com.example.demo.core.member.domain;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;

--- a/src/main/java/com/example/demo/core/member/domain/MemberNickName2.java
+++ b/src/main/java/com/example/demo/core/member/domain/MemberNickName2.java
@@ -1,4 +1,4 @@
-package com.example.demo.infrastructure.persistence.member;
+package com.example.demo.core.member.domain;
 
 import lombok.Getter;
 

--- a/src/main/java/com/example/demo/core/member/domain/MemberNickName2Converter.java
+++ b/src/main/java/com/example/demo/core/member/domain/MemberNickName2Converter.java
@@ -1,4 +1,4 @@
-package com.example.demo.infrastructure.persistence.member;
+package com.example.demo.core.member.domain;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;


### PR DESCRIPTION
infrastructure에 있던 클래스와 컨버터를 core로 옮김
아크유닛 레이어 아키텍처 검증을 통과하기 위함

본 프로젝트 패키지 구조상 Jpa 관련 코드 (컨버터 등)이 core에 직접적으로 침투하는 구조라서 나중에 도메인 엔티티와 Jpa 엔티티를 분리하는 것도 고려해봐야할 듯