### PR TITLE
Feature/add kafka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.1.0'
     testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.3'
     testImplementation 'org.mockito:mockito-core:5.13.0'

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+    implementation 'org.springframework.kafka:spring-kafka'
+
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,3 +22,31 @@ services:
       MYSQL_ROOT_PASSWORD: root
     ports:
       - "3306:3306"
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 22181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "22181:22181"
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:22181
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:29092,EXTERNAL://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+  kafka-ui:
+    image: provectuslabs/kafka-ui
+    container_name: kafka-ui
+    ports:
+      - "28080:8080"
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:29092
+      - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper:22181

--- a/src/main/java/com/example/demo/config/kafka/KafkaConfig.java
+++ b/src/main/java/com/example/demo/config/kafka/KafkaConfig.java
@@ -1,7 +1,6 @@
 package com.example.demo.config.kafka;
 
-import com.fasterxml.jackson.databind.ser.std.StringSerializer;
-import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/example/demo/config/kafka/KafkaConfig.java
+++ b/src/main/java/com/example/demo/config/kafka/KafkaConfig.java
@@ -1,0 +1,41 @@
+package com.example.demo.config.kafka;
+
+import com.fasterxml.jackson.databind.ser.std.StringSerializer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    @Value("${kafka.producer.bootstrap-servers}")
+    private String bootstrapServer;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        config.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/example/demo/config/kafka/KafkaConfig.java
+++ b/src/main/java/com/example/demo/config/kafka/KafkaConfig.java
@@ -1,5 +1,6 @@
 package com.example.demo.config.kafka;
 
+import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -8,6 +9,7 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,6 +17,7 @@ import java.util.Map;
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.springframework.kafka.support.serializer.JsonSerializer.ADD_TYPE_INFO_HEADERS;
 
 @EnableKafka
 @Configuration
@@ -24,17 +27,18 @@ public class KafkaConfig {
     private String bootstrapServer;
 
     @Bean
-    public ProducerFactory<String, Object> producerFactory() {
+    public ProducerFactory<String, Message> producerFactory() {
         Map<String, Object> config = new HashMap<>();
         config.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
         config.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        config.put(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        config.put(ADD_TYPE_INFO_HEADERS, false);
 
         return new DefaultKafkaProducerFactory<>(config);
     }
 
     @Bean
-    public KafkaTemplate<String, Object> kafkaTemplate() {
+    public KafkaTemplate<String, Message> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
 }

--- a/src/main/java/com/example/demo/core/product/service/CreateProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/CreateProductService.java
@@ -3,24 +3,21 @@ package com.example.demo.core.product.service;
 import com.example.demo.common.exceptions.BusinessErrorCode;
 import com.example.demo.common.exceptions.BusinessException;
 import com.example.demo.core.product.domain.Product;
-import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.product.param.CreateProductParam;
+import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.infrastructure.persistence.product.ProductRepository;
 import com.example.demo.infrastructure.persistence.stock.StockRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class CreateProductService {
 
     private final ProductRepository productRepository;
     private final StockRepository stockRepository;
-
-    public CreateProductService(ProductRepository productRepository, StockRepository stockRepository) {
-        this.productRepository = productRepository;
-        this.stockRepository = stockRepository;
-    }
 
     public void create(CreateProductParam param) {
         validateDuplicatedProduct(param.getProductCode());

--- a/src/main/java/com/example/demo/core/product/service/CreateProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/CreateProductService.java
@@ -25,7 +25,7 @@ public class CreateProductService {
         validateDuplicatedProduct(param.getProductCode());
 
         Stock stock = stockRepository.save(param.toStockEntity());
-        productRepository.save(param.toProductEntity(stock));
+        Product product = productRepository.save(param.toProductEntity(stock));
 
         productKafkaPublisher.create();
     }

--- a/src/main/java/com/example/demo/core/product/service/CreateProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/CreateProductService.java
@@ -5,6 +5,7 @@ import com.example.demo.common.exceptions.BusinessException;
 import com.example.demo.core.product.domain.Product;
 import com.example.demo.core.product.param.CreateProductParam;
 import com.example.demo.core.stock.domain.Stock;
+import com.example.demo.infrastructure.kafka.product.CreateProductPayload;
 import com.example.demo.infrastructure.kafka.product.ProductKafkaPublisher;
 import com.example.demo.infrastructure.persistence.product.ProductRepository;
 import com.example.demo.infrastructure.persistence.stock.StockRepository;
@@ -27,7 +28,11 @@ public class CreateProductService {
         final Stock stock = stockRepository.save(param.toStockEntity());
         final Product product = productRepository.save(param.toProductEntity(stock));
 
-        productKafkaPublisher.create();
+        productKafkaPublisher.create(CreateProductPayload.builder()
+            .productCode(product.getProductCode())
+            .productName(product.getProductName())
+            .productAmount(product.getProductAmount())
+            .build());
     }
 
     private void validateDuplicatedProduct(String productCode) {

--- a/src/main/java/com/example/demo/core/product/service/CreateProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/CreateProductService.java
@@ -21,11 +21,11 @@ public class CreateProductService {
     private final StockRepository stockRepository;
     private final ProductKafkaPublisher productKafkaPublisher;
 
-    public void create(CreateProductParam param) {
+    public void create(final CreateProductParam param) {
         validateDuplicatedProduct(param.getProductCode());
 
-        Stock stock = stockRepository.save(param.toStockEntity());
-        Product product = productRepository.save(param.toProductEntity(stock));
+        final Stock stock = stockRepository.save(param.toStockEntity());
+        final Product product = productRepository.save(param.toProductEntity(stock));
 
         productKafkaPublisher.create();
     }

--- a/src/main/java/com/example/demo/core/product/service/CreateProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/CreateProductService.java
@@ -5,6 +5,7 @@ import com.example.demo.common.exceptions.BusinessException;
 import com.example.demo.core.product.domain.Product;
 import com.example.demo.core.product.param.CreateProductParam;
 import com.example.demo.core.stock.domain.Stock;
+import com.example.demo.infrastructure.kafka.product.ProductKafkaPublisher;
 import com.example.demo.infrastructure.persistence.product.ProductRepository;
 import com.example.demo.infrastructure.persistence.stock.StockRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,12 +19,15 @@ public class CreateProductService {
 
     private final ProductRepository productRepository;
     private final StockRepository stockRepository;
+    private final ProductKafkaPublisher productKafkaPublisher;
 
     public void create(CreateProductParam param) {
         validateDuplicatedProduct(param.getProductCode());
 
         Stock stock = stockRepository.save(param.toStockEntity());
         productRepository.save(param.toProductEntity(stock));
+
+        productKafkaPublisher.create();
     }
 
     private void validateDuplicatedProduct(String productCode) {

--- a/src/main/java/com/example/demo/infrastructure/kafka/product/CreateProductPayload.java
+++ b/src/main/java/com/example/demo/infrastructure/kafka/product/CreateProductPayload.java
@@ -1,0 +1,9 @@
+package com.example.demo.infrastructure.kafka.product;
+
+import lombok.Builder;
+
+@Builder
+public record CreateProductPayload(String productCode,
+                                   String productName,
+                                   long productAmount) {
+}

--- a/src/main/java/com/example/demo/infrastructure/kafka/product/ProductKafkaPublisher.java
+++ b/src/main/java/com/example/demo/infrastructure/kafka/product/ProductKafkaPublisher.java
@@ -1,10 +1,17 @@
 package com.example.demo.infrastructure.kafka.product;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.protocol.Message;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 
+import static org.springframework.kafka.support.KafkaHeaders.KEY;
+import static org.springframework.kafka.support.KafkaHeaders.TOPIC;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ProductKafkaPublisher {
@@ -14,7 +21,15 @@ public class ProductKafkaPublisher {
 
     private final KafkaTemplate<String, Message> kafkaTemplate;
 
-    public void create() {
-        kafkaTemplate.send(createProductTopic, "say hello~");
+    public void create(final CreateProductPayload payload) {
+        kafkaTemplate.send(MessageBuilder.withPayload(payload)
+                .setHeader(TOPIC, createProductTopic)
+                .setHeader(KEY, payload.productCode())
+            .build())
+            .thenAccept(result -> log.info("카프카 메시지 발행 성공!!"))
+            .exceptionally(exception -> {
+                log.error("메시지 발행 실패");
+                return null;
+            });
     }
 }

--- a/src/main/java/com/example/demo/infrastructure/kafka/product/ProductKafkaPublisher.java
+++ b/src/main/java/com/example/demo/infrastructure/kafka/product/ProductKafkaPublisher.java
@@ -1,0 +1,16 @@
+package com.example.demo.infrastructure.kafka.product;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProductKafkaPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void create() {
+        kafkaTemplate.send("topic", "say hello~");
+    }
+}

--- a/src/main/java/com/example/demo/infrastructure/kafka/product/ProductKafkaPublisher.java
+++ b/src/main/java/com/example/demo/infrastructure/kafka/product/ProductKafkaPublisher.java
@@ -12,7 +12,7 @@ public class ProductKafkaPublisher {
     @Value("${kafka.producer.topics.create-product}")
     private String createProductTopic;
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final KafkaTemplate<String, Message> kafkaTemplate;
 
     public void create() {
         kafkaTemplate.send(createProductTopic, "say hello~");

--- a/src/main/java/com/example/demo/infrastructure/kafka/product/ProductKafkaPublisher.java
+++ b/src/main/java/com/example/demo/infrastructure/kafka/product/ProductKafkaPublisher.java
@@ -1,6 +1,7 @@
 package com.example.demo.infrastructure.kafka.product;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
@@ -8,9 +9,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProductKafkaPublisher {
 
+    @Value("${kafka.producer.topics.create-product}")
+    private String createProductTopic;
+
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     public void create() {
-        kafkaTemplate.send("topic", "say hello~");
+        kafkaTemplate.send(createProductTopic, "say hello~");
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,10 @@ management:
     tracing:
       endpoint: http://localhost:9411/api/v2/spans
 
+kafka:
+  producer:
+    bootstrap-servers: localhost:9092
+
 logging:
   pattern:
     level: "%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,8 @@ management:
 kafka:
   producer:
     bootstrap-servers: localhost:9092
+    topics:
+      create-product: "create-product"
 
 logging:
   pattern:

--- a/src/test/java/com/example/demo/core/product/service/CreateProductServiceTest.java
+++ b/src/test/java/com/example/demo/core/product/service/CreateProductServiceTest.java
@@ -6,6 +6,7 @@ import com.example.demo.common.exceptions.BusinessException;
 import com.example.demo.core.product.domain.Product;
 import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.product.param.CreateProductParam;
+import com.example.demo.infrastructure.kafka.product.ProductKafkaPublisher;
 import com.example.demo.infrastructure.persistence.product.ProductRepository;
 import com.example.demo.infrastructure.persistence.stock.StockRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -14,12 +15,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 
 import static com.example.demo.ProductFixtures.PRODUCT_CODE;
 import static com.example.demo.ProductFixtures.PRODUCT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@EmbeddedKafka(
+    brokerProperties = {
+        "listeners=PLAINTEXT://localhost:9092"
+    },
+    ports = { 9092 }
+)
 @IntegrationTest
 @DisplayName("CreateProductService")
 class CreateProductServiceTest {
@@ -32,6 +40,9 @@ class CreateProductServiceTest {
 
     @Autowired
     private StockRepository stockRepository;
+
+    @Autowired
+    private ProductKafkaPublisher productKafkaPublisher;
 
     @AfterEach
     void tearDown() {


### PR DESCRIPTION
`spring-kafka`를 추가하여 카프카 메시지 발행 구현

전전 회사(컬리)에서는 `spring-kafka`를 사용했고, 전 회사(카카오페이손해보험)에서는 `spring-cloud-stream-binder-kafka`를 사용했음
서로 장단점이 있으나, 다른 회사에서도 보편적으로 사용하는 `spring-kafka`로 진행

`spring-kafka` 최신 버전이 됨에 따라 KafkaTemplate으로 메시지를 발행했을 때 콜백 구현이 변경된 점 확인
과거에는 .addCallback()으로 발행 성공, 실패에 대한 후처리를 지원했으나 최신 버전에서는 .thenAccept()와 .exceptionally()로 변경된 듯

카프카 작업 외로 이번 작업을 하면서 레이어드 아키텍처의 한계를 느낄 수 있었음
`CreateProductPayload(카프카 페이로드)`가 infrastructure에 위치하고 있어서 Product(도메인 객체)와 CreateProductPayload(DTO)간 변환을 서비스 레이어에서 밖에 할 수 없고, 비즈니스 로직 외에 데이터 변환 코드가 들어간다는 점
헥사고날 아키텍처였다면 의존성 역전을 통해 도메인 객체를 infrastructure로 넘기고, infrastructure에서 데이터 변환이 가능함
ArchUnit이 없던 실무 프로젝트에서는 유도리 있게 했지만, ArchUnit으로 레이어 검증을 피트니스 함수화 시킨 본 프로젝트에서는 레이어간 참조 가능 여부는 절대적인 법칙이라 다른 방법을 찾아봐야할 듯

레이어드 아키텍처에서 infrastructure를 추상화할 수가 있는 것일까? 라는 의문이 생김
레이어드 아키텍처를 도식화한 그림을 보면 service가 infrastructure를 알 수 밖에 없는 구조이긴 함
그래서 우선 ProductKafkaPublisher를 인터페이스가 아니라 클래스로 구현

본 프로젝트에서 infrastructure를 추상화하려면 infrastructure 패키지 구조 변경도 고려해봐야할 듯
`infrastructure.구현체.도메인` 에서 `infrastructure.도메인.구현체`로 패키지 구조가 변경되야 단일 인터페이스를 통해 service와 infrastructure간 통신이 가능해보임
service 입장에서는 카프카던, DB던, Redis던 관심사는 아니기 때문에