### PR TITLE
Feature/add caffeine cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 //    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 

--- a/src/main/java/com/example/demo/config/cache/CacheConfig.java
+++ b/src/main/java/com/example/demo/config/cache/CacheConfig.java
@@ -1,0 +1,10 @@
+package com.example.demo.config.cache;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+    //
+}

--- a/src/main/java/com/example/demo/core/product/param/SearchProductParam.java
+++ b/src/main/java/com/example/demo/core/product/param/SearchProductParam.java
@@ -1,34 +1,20 @@
 package com.example.demo.core.product.param;
 
 import com.example.demo.common.enums.product.ProductStatus;
-import lombok.Getter;
 import org.springframework.data.domain.PageRequest;
 
-@Getter
-public class SearchProductParam {
+public record SearchProductParam(String productName,
+                                 Long minProductAmount,
+                                 Long maxProductAmount,
+                                 ProductStatus productStatus,
+                                 PageRequest pageable) {
 
-    private final String productName;
-
-    private final Long minProductAmount;
-
-    private final Long maxProductAmount;
-
-    private final ProductStatus productStatus;
-
-    private final PageRequest pageable;
-
-    public SearchProductParam(
-        String productName,
-        Long minProductAmount,
-        Long maxProductAmount,
-        ProductStatus productStatus,
-        int pageNumber,
-        int pageSize
-    ) {
-        this.productName = productName;
-        this.minProductAmount = minProductAmount;
-        this.maxProductAmount = maxProductAmount;
-        this.productStatus = productStatus;
-        this.pageable = PageRequest.of(pageNumber, pageSize);
+    public SearchProductParam(String productName,
+                              Long minProductAmount,
+                              Long maxProductAmount,
+                              ProductStatus productStatus,
+                              int pageNumber,
+                              int pageSize) {
+        this(productName, minProductAmount, maxProductAmount, productStatus, PageRequest.of(pageNumber, pageSize));
     }
 }

--- a/src/main/java/com/example/demo/core/product/result/SearchProductResult.java
+++ b/src/main/java/com/example/demo/core/product/result/SearchProductResult.java
@@ -5,18 +5,17 @@ import lombok.Getter;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.List;
 
 @Getter
 public class SearchProductResult {
 
-    private final Set<Product> products;
+    private final List<Product> products;
     private final long pageNumber;
     private final long pageSize;
     private final long totalCount;
 
-    public SearchProductResult(Set<Product> products, long pageNumber, long pageSize, long totalCount) {
+    public SearchProductResult(List<Product> products, long pageNumber, long pageSize, long totalCount) {
         this.products = products;
         this.pageNumber = pageNumber;
         this.pageSize = pageSize;
@@ -63,7 +62,7 @@ public class SearchProductResult {
 
     public static SearchProductResult from(Page<com.example.demo.core.product.domain.Product> products) {
         return new SearchProductResult(
-            products.getContent().stream().map(Product::from).collect(Collectors.toSet()),
+            products.getContent().stream().map(Product::from).toList(),
             products.getPageable().getPageNumber(),
             products.getPageable().getPageSize(),
             products.getTotalElements()

--- a/src/main/java/com/example/demo/core/product/service/SearchProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/SearchProductService.java
@@ -17,8 +17,8 @@ public class SearchProductService {
 
     private final ProductCustomRepository productCustomRepository;
 
-    public SearchProductResult search(SearchProductParam param) {
-        Page<Product> products = productCustomRepository.search(param);
+    public SearchProductResult search(final SearchProductParam param) {
+        final Page<Product> products = productCustomRepository.search(param);
 
         return SearchProductResult.from(products);
     }

--- a/src/main/java/com/example/demo/core/product/service/SearchProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/SearchProductService.java
@@ -4,19 +4,17 @@ import com.example.demo.core.product.domain.Product;
 import com.example.demo.core.product.param.SearchProductParam;
 import com.example.demo.core.product.result.SearchProductResult;
 import com.example.demo.infrastructure.persistence.product.ProductCustomRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional(readOnly = true)
 @Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class SearchProductService {
 
     private final ProductCustomRepository productCustomRepository;
-
-    public SearchProductService(ProductCustomRepository productCustomRepository) {
-        this.productCustomRepository = productCustomRepository;
-    }
 
     public SearchProductResult search(SearchProductParam param) {
         Page<Product> products = productCustomRepository.search(param);

--- a/src/main/java/com/example/demo/core/product/service/SearchProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/SearchProductService.java
@@ -23,7 +23,7 @@ public class SearchProductService {
         return SearchProductResult.from(products);
     }
 
-    @Cacheable(value = "products", key = "#param.pageable")
+    @Cacheable(value = "products", key = "#param")
     public SearchProductResult searchWithCache(final SearchProductParam param) {
         final Page<Product> products = productCustomRepository.search(param);
 

--- a/src/main/java/com/example/demo/core/product/service/SearchProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/SearchProductService.java
@@ -23,7 +23,7 @@ public class SearchProductService {
         return SearchProductResult.from(products);
     }
 
-    @Cacheable(value = "products", key = "#param.productStatus")
+    @Cacheable(value = "products", key = "#param.pageable")
     public SearchProductResult searchWithCache(final SearchProductParam param) {
         final Page<Product> products = productCustomRepository.search(param);
 

--- a/src/main/java/com/example/demo/core/product/service/SearchProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/SearchProductService.java
@@ -5,6 +5,7 @@ import com.example.demo.core.product.param.SearchProductParam;
 import com.example.demo.core.product.result.SearchProductResult;
 import com.example.demo.infrastructure.persistence.product.ProductCustomRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,13 @@ public class SearchProductService {
 
     public SearchProductResult search(SearchProductParam param) {
         Page<Product> products = productCustomRepository.search(param);
+
+        return SearchProductResult.from(products);
+    }
+
+    @Cacheable(value = "products", key = "#param.productStatus")
+    public SearchProductResult searchWithCache(final SearchProductParam param) {
+        final Page<Product> products = productCustomRepository.search(param);
 
         return SearchProductResult.from(products);
     }

--- a/src/main/java/com/example/demo/infrastructure/persistence/product/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/product/ProductCustomRepositoryImpl.java
@@ -27,15 +27,15 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
         JPQLQuery<Product> query = queryFactory
             .selectFrom(product)
             .where(
-                eqProductStatus(product, param.getProductStatus()),
-                goeProductAmount(product, param.getMinProductAmount()),
-                loeProductAmount(product, param.getMaxProductAmount()),
-                containProductName(product, param.getProductName())
+                eqProductStatus(product, param.productStatus()),
+                goeProductAmount(product, param.minProductAmount()),
+                loeProductAmount(product, param.maxProductAmount()),
+                containProductName(product, param.productName())
             )
-            .offset(param.getPageable().getOffset())
-            .limit(param.getPageable().getPageSize());
+            .offset(param.pageable().getOffset())
+            .limit(param.pageable().getPageSize());
 
-        return new PageImpl<>(query.fetch(), param.getPageable(), query.fetchCount());
+        return new PageImpl<>(query.fetch(), param.pageable(), query.fetchCount());
     }
 
     private BooleanExpression containProductName(QProduct product, String productName) {

--- a/src/main/java/com/example/demo/infrastructure/persistence/product/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/product/ProductCustomRepositoryImpl.java
@@ -21,10 +21,10 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
     }
 
     @Override
-    public Page<Product> search(SearchProductParam param) {
+    public Page<Product> search(final SearchProductParam param) {
         final QProduct product = QProduct.product;
 
-        JPQLQuery<Product> query = queryFactory
+        final JPQLQuery<Product> query = queryFactory
             .selectFrom(product)
             .where(
                 eqProductStatus(product, param.productStatus()),

--- a/src/main/java/com/example/demo/web/v1/product/FindProductSalesController.java
+++ b/src/main/java/com/example/demo/web/v1/product/FindProductSalesController.java
@@ -1,7 +1,6 @@
 package com.example.demo.web.v1.product;
 
 import com.example.demo.core.product.param.FindProductSalesTop10Param;
-import com.example.demo.core.product.result.FindProductSalesResult;
 import com.example.demo.core.product.service.FindProductSalesService;
 import com.example.demo.web.ApiResponse;
 import com.example.demo.web.v1.product.response.FindProductSalesResponse;

--- a/src/main/java/com/example/demo/web/v1/product/SearchProductController.java
+++ b/src/main/java/com/example/demo/web/v1/product/SearchProductController.java
@@ -6,19 +6,17 @@ import com.example.demo.web.ApiResponse;
 import com.example.demo.web.v1.product.request.SearchProductRequest;
 import com.example.demo.web.v1.product.response.SearchProductResponse;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class SearchProductController {
 
     private final SearchProductService searchProductService;
-
-    public SearchProductController(SearchProductService searchProductService) {
-        this.searchProductService = searchProductService;
-    }
 
     @GetMapping("/v1/products")
     public ApiResponse<SearchProductResponse> search(@RequestParam(required = false, defaultValue = "true") boolean cache,

--- a/src/main/java/com/example/demo/web/v1/product/SearchProductController.java
+++ b/src/main/java/com/example/demo/web/v1/product/SearchProductController.java
@@ -8,6 +8,7 @@ import com.example.demo.web.v1.product.response.SearchProductResponse;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,8 +21,11 @@ public class SearchProductController {
     }
 
     @GetMapping("/v1/products")
-    public ApiResponse<SearchProductResponse> search(@ModelAttribute @Valid SearchProductRequest request) {
-        SearchProductResult result = searchProductService.search(request.toParam());
+    public ApiResponse<SearchProductResponse> search(@RequestParam(required = false, defaultValue = "true") boolean cache,
+                                                     @ModelAttribute @Valid SearchProductRequest request) {
+        final SearchProductResult result = cache
+            ? searchProductService.searchWithCache(request.toParam())
+            : searchProductService.search(request.toParam());
 
         return ApiResponse.success(SearchProductResponse.from(result));
     }

--- a/src/main/java/com/example/demo/web/v1/product/request/SearchProductRequest.java
+++ b/src/main/java/com/example/demo/web/v1/product/request/SearchProductRequest.java
@@ -17,14 +17,12 @@ public class SearchProductRequest extends PageRequest {
 
     private final ProductStatus productStatus;
 
-    public SearchProductRequest(
-        String productName,
-        Long minProductAmount,
-        Long maxProductAmount,
-        ProductStatus productStatus,
-        Integer pageNumber,
-        Integer pageSize
-    ) {
+    public SearchProductRequest(String productName,
+                                Long minProductAmount,
+                                Long maxProductAmount,
+                                ProductStatus productStatus,
+                                Integer pageNumber,
+                                Integer pageSize) {
         super(pageNumber, pageSize);
         this.productName = productName;
         this.minProductAmount = minProductAmount;
@@ -34,12 +32,11 @@ public class SearchProductRequest extends PageRequest {
 
     public SearchProductParam toParam() {
         return new SearchProductParam(
-            productName.trim(),
+            productName == null ? productName : productName.trim(),
             minProductAmount,
             maxProductAmount,
             productStatus,
             getPageNumber(),
-            getPageSize()
-        );
+            getPageSize());
     }
 }

--- a/src/main/java/com/example/demo/web/v1/product/response/SearchProductResponse.java
+++ b/src/main/java/com/example/demo/web/v1/product/response/SearchProductResponse.java
@@ -23,7 +23,7 @@ public class SearchProductResponse extends PageResponse {
     }
 
     @Getter
-    private static class Product {
+    public static class Product {
         private final String productCode;
 
         private final String productName;

--- a/src/main/java/com/example/demo/web/v1/product/response/SearchProductResponse.java
+++ b/src/main/java/com/example/demo/web/v1/product/response/SearchProductResponse.java
@@ -7,8 +7,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.List;
 
 import static com.example.demo.common.constants.DateFormatConstants.ISO_8601;
 import static com.example.demo.common.constants.DateFormatConstants.TIMEZONE;
@@ -16,9 +15,9 @@ import static com.example.demo.common.constants.DateFormatConstants.TIMEZONE;
 @Getter
 public class SearchProductResponse extends PageResponse {
 
-    private final Set<Product> products;
+    private final List<Product> products;
 
-    public SearchProductResponse(Set<Product> products, long pageNumber, long pageSize, long totalCount) {
+    public SearchProductResponse(List<Product> products, long pageNumber, long pageSize, long totalCount) {
         super(pageNumber, pageSize, totalCount);
         this.products = products;
     }
@@ -39,14 +38,12 @@ public class SearchProductResponse extends PageResponse {
         @JsonFormat(pattern = ISO_8601, timezone = TIMEZONE)
         private final LocalDateTime updatedAt;
 
-        private Product(
-            String productCode,
-            String productName,
-            ProductStatus productStatus,
-            long productAmount,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-        ) {
+        private Product(String productCode,
+                        String productName,
+                        ProductStatus productStatus,
+                        long productAmount,
+                        LocalDateTime createdAt,
+                        LocalDateTime updatedAt) {
             this.productCode = productCode;
             this.productName = productName;
             this.productStatus = productStatus;
@@ -62,17 +59,15 @@ public class SearchProductResponse extends PageResponse {
                 product.getProductStatus(),
                 product.getProductAmount(),
                 product.getCreatedAt(),
-                product.getUpdatedAt()
-            );
+                product.getUpdatedAt());
         }
     }
 
     public static SearchProductResponse from(SearchProductResult product) {
         return new SearchProductResponse(
-            product.getProducts().stream().map(Product::from).collect(Collectors.toSet()),
+            product.getProducts().stream().map(Product::from).toList(),
             product.getPageNumber(),
             product.getPageSize(),
-            product.getTotalCount()
-        );
+            product.getTotalCount());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
   cache:
     type: caffeine
   caffeine:
-    spec: maximumSize=100,expireAfterWrite=5m
+    spec: maximumSize=100,expireAfterWrite=1m
 
 management:
   tracing:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,10 @@ spring:
   zipkin:
     enabled: true
     base-url: http://localhost:9411
+  cache:
+    type: caffeine
+  caffeine:
+    spec: maximumSize=100,expireAfterWrite=5m
 
 management:
   tracing:

--- a/src/test/java/com/example/demo/core/product/service/SearchProductServiceTest.java
+++ b/src/test/java/com/example/demo/core/product/service/SearchProductServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDate;
 
 import static com.example.demo.ProductFixtures.PRODUCT_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 @IntegrationTest
@@ -54,17 +55,18 @@ class SearchProductServiceTest extends TestDataInsertSupport {
         }
 
         @Nested
-        @DisplayName("검색 조건에 맞는 데이터를 조회하여")
-        class Context_notFoundData {
+        @DisplayName("검색 조건에 맞는 데이터가 존재한다면")
+        class Context_found_data {
 
             final SearchProductParam param = new SearchProductParam(null, null, null, null, 0, 10);
 
             @Test
-            @DisplayName("SearchProductResult 타입으로 리턴한다.")
+            @DisplayName("데이터를 리턴한다.")
             void it() {
-                SearchProductResult result = searchProductService.search(param);
+                final SearchProductResult actual = searchProductService.search(param);
 
-                assertInstanceOf(SearchProductResult.class, result);
+                assertInstanceOf(SearchProductResult.class, actual);
+                assertEquals(1, actual.getProducts().size());
             }
         }
     }

--- a/src/test/java/com/example/demo/core/product/service/SearchProductServiceTest.java
+++ b/src/test/java/com/example/demo/core/product/service/SearchProductServiceTest.java
@@ -29,10 +29,10 @@ class SearchProductServiceTest extends TestDataInsertSupport {
     private SearchProductService searchProductService;
 
     @Autowired
-    StockRepository stockRepository;
+    private StockRepository stockRepository;
 
     @Autowired
-    ProductRepository productRepository;
+    private ProductRepository productRepository;
 
     @AfterEach
     void tearDown() {


### PR DESCRIPTION
로컬 (카페인) 캐시 적용 PR

캐시 적용 작업은 어렵지 않았으나, 적용 과정에서 2가지 이슈 발생

1. 코틀린의 by lazy
서비스 레이어 dto인 `SearchProductParam`의 `pageable` 필드의 타입이 `PageRequest`인게 적절하지 않다고 판단
`int pageNumber`과 `int pageSize`로 Repository까지 넘겨서 RepositoryImpl에서 `PageRequest`를 생성하려고 했으나, `PageRequest`가 3군데에서 필요
RepositoryImpl 내에 변수 선언 외에 다른 방법이 있는지 고민해보았고, 코틀린의 by lazy가 떠오름

아래와 같이 by lazy를 사용하여 PageRequest 객체를 한번만 생성하고 싶었으나, 자바는 직접 구현하는 것 외에 방법이 없는 듯 함
```
data class SearchProductParam(
    private val pageNumber: Int,
    private val pageSize: Int,
) {
    private val pageable: PageRequest by lazy {
        PageRequest.of(pageNumber, pageSize)
    }
}
```


2. Set<>을 stream()으로 처리 시 순서 보장 안되는 문제
상품 조회 API를 호출할 때마다 데이터 순서가 바뀌는 현상 발견
DB 데이터 조회 결과와 서비스의 stream(), 컨트롤러의 stream() 각각 로그를 찍어보니 단계별로 데이터 순서가 바뀌는 것 확인
원인은 return 데이터 구조가 `Set<Product>`라서 그런 것으로 확인
Set<>을 stream()으로 처리 시 순서 보장 안되는 문제를 처음 알게 됨
