### PR TITLE
 Feature/add propagation

### DIFF
--- a/src/main/java/com/example/demo/core/product/service/SearchProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/SearchProductService.java
@@ -8,10 +8,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
 @RequiredArgsConstructor
 public class SearchProductService {
 


### PR DESCRIPTION
카카오페이 기술블로그에서 소개 중인 `@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)` 테스트 PR
https://tech.kakaopay.com/post/jpa-transactional-bri/

기존에도 Master(Write)와 Slave(Read)를 분리하기 위해 Datasource 설정을 하고, 데이터 조회 클래스(함수)에는 `@Transactional(readOnly = true)`를 선언해서 Slave에 붙도록 작업은 해왔음
다만, `@Transactional(readOnly = true)`여도 추가적인 트랜잭션 쿼리를 DBMS에 요청한다는 사실은 이번 작업을 통해 알게 됨
이런게 AOP의 장점이자 단점인 듯
사용하기에는 편하지만, 내부 구현을 꼼꼼하게 확인하지 않게 됨
성능 테스트는 해보지 못 했으나, 기술블로그 내용을 봤을 때 성능에 큰 영향이 있어보임

`@Transactional을 쓸 상황을 최대한 줄이자`라는 저자의 의견에 공감
사실 트랜잭션은 다수의 데이터 처리 시 원자성을 보장하기 위함인데, 큰 고민 없이 `@Transactional`을 선언해놓은 코드를 종종 보게 됨
단일 저장, 단일 업데이트, 조회 등등
팀 동료의 이전 조직에서는 Datasource의 기본 설정을 Slave(Read)를 바라보게 했다는 얘기를 들은 적이 있음
그 때는 이해가 안갔지만, (Failover 케이스는 제외하고 생각했을 때) DB 관점에서는 그게 맞을 수도 있겠다라는 생각이 듦


테스트 검증 용 Mysql general log 조회 쿼리
```
SELECT event_time, CONVERT(argument USING utf8) 
FROM mysql.general_log
WHERE user_host like 'root%'
and command_type = 'Query' 
order by event_time desc;
```

1. `@Transacitonal`이 없을 때
```
'2025-02-05 13:10:28.507497','select count(p1_0.product_id) from product p1_0'
'2025-02-05 13:10:28.501852','select p1_0.product_id,p1_0.product_type,p1_0.created_at,p1_0.created_by,p1_0.product_amount,p1_0.product_code,p1_0.product_name,p1_0.product_status,p1_0.stock_id,p1_0.updated_at,p1_0.updated_by,p1_0.volt_type,p1_0.expiration_date from product p1_0 limit 0,10'
```

2. `@Transacitonal`을 선언했을 때
```
'2025-02-05 13:09:19.134738','SET autocommit=1'
'2025-02-05 13:09:19.133487','commit'
'2025-02-05 13:09:19.131072','select count(p1_0.product_id) from product p1_0'
'2025-02-05 13:09:19.124989','select p1_0.product_id,p1_0.product_type,p1_0.created_at,p1_0.created_by,p1_0.product_amount,p1_0.product_code,p1_0.product_name,p1_0.product_status,p1_0.stock_id,p1_0.updated_at,p1_0.updated_by,p1_0.volt_type,p1_0.expiration_date from product p1_0 limit 0,10'
'2025-02-05 13:09:19.122611','SET autocommit=0'
```

3. `@Transacitonal(readOnly = true)`을 선언했을 때
```
'2025-02-05 13:08:05.889682','set session transaction read write'
'2025-02-05 13:08:05.888186','SET autocommit=1'
'2025-02-05 13:08:05.886825','commit'
'2025-02-05 13:08:05.884920','select count(p1_0.product_id) from product p1_0'
'2025-02-05 13:08:05.879411','select p1_0.product_id,p1_0.product_type,p1_0.created_at,p1_0.created_by,p1_0.product_amount,p1_0.product_code,p1_0.product_name,p1_0.product_status,p1_0.stock_id,p1_0.updated_at,p1_0.updated_by,p1_0.volt_type,p1_0.expiration_date from product p1_0 limit 0,10'
'2025-02-05 13:08:05.877544','SET autocommit=0'
'2025-02-05 13:08:05.875828','set session transaction read only'
```

4. `@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)`을 선언했을 때
```
'2025-02-05 13:06:37.979816','select count(p1_0.product_id) from product p1_0'
'2025-02-05 13:06:37.975190','select p1_0.product_id,p1_0.product_type,p1_0.created_at,p1_0.created_by,p1_0.product_amount,p1_0.product_code,p1_0.product_name,p1_0.product_status,p1_0.stock_id,p1_0.updated_at,p1_0.updated_by,p1_0.volt_type,p1_0.expiration_date from product p1_0 limit 0,10'
```