### PR TITLE
Feature/renaming querydsl

### DIFF
--- a/src/main/java/com/example/demo/core/product/service/SearchProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/SearchProductService.java
@@ -25,8 +25,6 @@ public class SearchProductService {
 
     @Cacheable(value = "products", key = "#param")
     public SearchProductResult searchWithCache(final SearchProductParam param) {
-        final Page<Product> products = productRepository.search(param);
-
-        return SearchProductResult.from(products);
+        return search(param);
     }
 }

--- a/src/main/java/com/example/demo/core/product/service/SearchProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/SearchProductService.java
@@ -4,7 +4,7 @@ import com.example.demo.config.persistence.ReadTransactional;
 import com.example.demo.core.product.domain.Product;
 import com.example.demo.core.product.param.SearchProductParam;
 import com.example.demo.core.product.result.SearchProductResult;
-import com.example.demo.infrastructure.persistence.product.ProductRepositoryCustom;
+import com.example.demo.infrastructure.persistence.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
@@ -15,17 +15,17 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SearchProductService {
 
-    private final ProductRepositoryCustom productRepositoryCustom;
+    private final ProductRepository productRepository;
 
     public SearchProductResult search(final SearchProductParam param) {
-        final Page<Product> products = productRepositoryCustom.search(param);
+        final Page<Product> products = productRepository.search(param);
 
         return SearchProductResult.from(products);
     }
 
     @Cacheable(value = "products", key = "#param")
     public SearchProductResult searchWithCache(final SearchProductParam param) {
-        final Page<Product> products = productRepositoryCustom.search(param);
+        final Page<Product> products = productRepository.search(param);
 
         return SearchProductResult.from(products);
     }

--- a/src/main/java/com/example/demo/core/product/service/SearchProductService.java
+++ b/src/main/java/com/example/demo/core/product/service/SearchProductService.java
@@ -4,7 +4,7 @@ import com.example.demo.config.persistence.ReadTransactional;
 import com.example.demo.core.product.domain.Product;
 import com.example.demo.core.product.param.SearchProductParam;
 import com.example.demo.core.product.result.SearchProductResult;
-import com.example.demo.infrastructure.persistence.product.ProductCustomRepository;
+import com.example.demo.infrastructure.persistence.product.ProductRepositoryCustom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
@@ -15,17 +15,17 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SearchProductService {
 
-    private final ProductCustomRepository productCustomRepository;
+    private final ProductRepositoryCustom productRepositoryCustom;
 
     public SearchProductResult search(final SearchProductParam param) {
-        final Page<Product> products = productCustomRepository.search(param);
+        final Page<Product> products = productRepositoryCustom.search(param);
 
         return SearchProductResult.from(products);
     }
 
     @Cacheable(value = "products", key = "#param")
     public SearchProductResult searchWithCache(final SearchProductParam param) {
-        final Page<Product> products = productCustomRepository.search(param);
+        final Page<Product> products = productRepositoryCustom.search(param);
 
         return SearchProductResult.from(products);
     }

--- a/src/main/java/com/example/demo/infrastructure/persistence/product/ProductRepository.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/product/ProductRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends ProductRepositoryCustom, JpaRepository<Product, Long> {
 
     Optional<Product> findByProductCode(String productCode);
 }

--- a/src/main/java/com/example/demo/infrastructure/persistence/product/ProductRepositoryCustom.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/product/ProductRepositoryCustom.java
@@ -4,7 +4,7 @@ import com.example.demo.core.product.domain.Product;
 import com.example.demo.core.product.param.SearchProductParam;
 import org.springframework.data.domain.Page;
 
-public interface ProductCustomRepository {
+public interface ProductRepositoryCustom {
 
     Page<Product> search(SearchProductParam param);
 }

--- a/src/main/java/com/example/demo/infrastructure/persistence/product/ProductRepositoryImpl.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/product/ProductRepositoryImpl.java
@@ -12,11 +12,11 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class ProductCustomRepositoryImpl implements ProductCustomRepository {
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-    public ProductCustomRepositoryImpl(JPAQueryFactory queryFactory) {
+    public ProductRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
     }
 

--- a/src/main/java/com/example/demo/infrastructure/persistence/product/ProductRepositoryImpl.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/product/ProductRepositoryImpl.java
@@ -9,9 +9,7 @@ import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;

--- a/src/main/java/com/example/demo/infrastructure/persistence/product/ProductRepositoryImpl.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/product/ProductRepositoryImpl.java
@@ -7,16 +7,14 @@ import com.example.demo.core.product.param.SearchProductParam;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 
+@RequiredArgsConstructor
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
-
-    public ProductRepositoryImpl(JPAQueryFactory queryFactory) {
-        this.queryFactory = queryFactory;
-    }
 
     @Override
     public Page<Product> search(final SearchProductParam param) {

--- a/src/test/java/com/example/demo/archunit/RepositoryUsageTest.java
+++ b/src/test/java/com/example/demo/archunit/RepositoryUsageTest.java
@@ -1,0 +1,55 @@
+package com.example.demo.archunit;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@AnalyzeClasses(packages = "com.example.demo")
+class RepositoryUsageTest {
+
+    private static final Set<String> customRepositoryNames;
+
+    static {
+        JavaClasses importedClasses = new ClassFileImporter().importPackages("com.example.demo"); // 패키지 경로 수정 필요
+        customRepositoryNames = importedClasses.stream()
+            .filter(clazz -> clazz.isInterface() && clazz.getName().endsWith("Custom"))
+            .map(JavaClass::getName)
+            .collect(Collectors.toSet());
+    }
+
+    @ArchTest
+    @DisplayName("서비스 계층에서 Custom Repository가 아닌 정식 Repository를 사용해야 한다 (필드, 생성자, 메서드 검사)")
+    void service_layer_should_not_use_custom_repositories(JavaClasses importedClasses) {
+        importedClasses.stream()
+            .filter(clazz -> clazz.isAnnotatedWith(Service.class))  // @Service가 있는 클래스만 필터링
+            .forEach(serviceClass -> {
+                // 필드 검사
+                serviceClass.getFields().forEach(field -> checkViolation(field, field.getRawType().getName()));
+                // 메서드 검사
+                serviceClass.getMethods().forEach(method ->
+                    method.getRawParameterTypes().forEach(paramType -> checkViolation(method, paramType.getName()))
+                );
+                // 생성자 검사
+                serviceClass.getConstructors().forEach(constructor ->
+                    constructor.getRawParameterTypes().forEach(paramType -> checkViolation(constructor, paramType.getName()))
+                );
+            });
+    }
+
+    private void checkViolation(JavaMember member, String typeName) {
+        if (customRepositoryNames.contains(typeName)) {
+            throw new AssertionError(String.format(
+                "❌ Violation: %s in class %s should not use Custom Repository %s",
+                member.getName(), member.getOwner().getName(), typeName
+            ));
+        }
+    }
+}

--- a/src/test/java/com/example/demo/infrastructure/persistence/product/ProductRepositoryImplTest.java
+++ b/src/test/java/com/example/demo/infrastructure/persistence/product/ProductRepositoryImplTest.java
@@ -24,16 +24,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RepositoryTest
 @DisplayName("ProductCustomRepositoryImpl")
-class ProductCustomRepositoryImplTest extends TestDataInsertSupport {
+class ProductRepositoryImplTest extends TestDataInsertSupport {
 
-    private ProductCustomRepositoryImpl productCustomRepositoryImpl;
+    private ProductRepositoryImpl productRepositoryImpl;
 
     @Autowired
     private JPAQueryFactory jpaQueryFactory;
 
     @BeforeEach
     void init() {
-        productCustomRepositoryImpl = new ProductCustomRepositoryImpl(jpaQueryFactory);
+        productRepositoryImpl = new ProductRepositoryImpl(jpaQueryFactory);
     }
 
     @Nested
@@ -71,7 +71,7 @@ class ProductCustomRepositoryImplTest extends TestDataInsertSupport {
             @Test
             @DisplayName("모든 데이터 4개를 리턴한다.")
             void it() {
-                Page<Product> result = productCustomRepositoryImpl.search(param);
+                Page<Product> result = productRepositoryImpl.search(param);
 
                 assertEquals(4, result.getContent().size());
             }
@@ -86,7 +86,7 @@ class ProductCustomRepositoryImplTest extends TestDataInsertSupport {
             @Test
             @DisplayName("'기'가 포함된 데이터 2개를 리턴한다.")
             void it() {
-                Page<Product> result = productCustomRepositoryImpl.search(param);
+                Page<Product> result = productRepositoryImpl.search(param);
 
                 assertEquals(2, result.getContent().size());
                 result.getContent().forEach(product -> assertTrue(product.getProductName().contains("기")));
@@ -102,7 +102,7 @@ class ProductCustomRepositoryImplTest extends TestDataInsertSupport {
             @Test
             @DisplayName("5000원보다 큰 데이터 3개를 리턴한다.")
             void it() {
-                Page<Product> result = productCustomRepositoryImpl.search(param);
+                Page<Product> result = productRepositoryImpl.search(param);
 
                 assertEquals(3, result.getContent().size());
                 result.getContent().forEach(product -> assertTrue(product.getProductAmount() >= 5000));
@@ -118,7 +118,7 @@ class ProductCustomRepositoryImplTest extends TestDataInsertSupport {
             @Test
             @DisplayName("10_000보다 작은 데이터 3개를 리턴한다.")
             void it() {
-                Page<Product> result = productCustomRepositoryImpl.search(param);
+                Page<Product> result = productRepositoryImpl.search(param);
 
                 assertEquals(3, result.getContent().size());
                 result.getContent().forEach(product -> assertTrue(product.getProductAmount() <= 10_000));
@@ -134,7 +134,7 @@ class ProductCustomRepositoryImplTest extends TestDataInsertSupport {
             @Test
             @DisplayName("상품 준비중인 데이터 1개를 리턴한다.")
             void it() {
-                Page<Product> result = productCustomRepositoryImpl.search(param);
+                Page<Product> result = productRepositoryImpl.search(param);
 
                 assertEquals(1, result.getContent().size());
                 result.getContent().forEach(product -> assertEquals(ProductStatus.READY, product.getProductStatus()));


### PR DESCRIPTION
Querydsl 인터페이스와 클래스 명명 방법을 다시 한번 정리하기 위한 PR

1. Querydsl 인터페이스명과 클래스명 교정
```
외부에 노출하는 레포지토리명: ProductRepository -> ProductRepository
Querydsl 레포지토리명: ProductCustomRepository -> ProductRepositoryCustom
Querydsl 구현체명: ProductCustomRepositoryImpl -> ProductRepositoryImpl
```

`Custom`이 마지막에 위치하는건 관례라고 함. 특별한 의미는 없는 듯.
기존에는 `Custom`이 가운데 위치하다보니 도메인적인 의미를 띄는 것처럼 느껴지긴 함. 마지막에 위치하는게 좋은 듯.
구현체는 `인터페이스명 + Impl`이 되야 `@Bean`으로 등록 됨

`ProductRepositoryImpl`, `ProductRepositoryCustomImpl` 둘다 가능
`ProductCustomRepositoryImpl`은 불가능
```
No qualifying bean of type 'com.example.demo.infrastructure.persistence.product.ProductRepositoryCustom' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
```


2. ProductRepository로 통합
Querydsl용 레포지토리(ProductRepositoryCustom)를 서비스 레이어에서 직접 호출하지 못 하도록 피트니스 함수 추가
<img width="1059" alt="스크린샷 2025-02-11 오후 9 38 54" src="https://github.com/user-attachments/assets/4a887c10-81b5-494a-b587-90ce8db64346" />

