### PR TITLE
Feature/add order no

### DIFF
--- a/src/main/java/com/example/demo/common/utils/OrderNoGenerator.java
+++ b/src/main/java/com/example/demo/common/utils/OrderNoGenerator.java
@@ -1,5 +1,6 @@
 package com.example.demo.common.utils;
 
+import com.example.demo.core.order.domain.OrderNo;
 import org.springframework.stereotype.Component;
 
 import java.nio.ByteBuffer;
@@ -11,11 +12,11 @@ public class OrderNoGenerator {
     private static final int LENGTH_10_INT_RADIX = 9;
 
     // TODO Redis 등을 활용하여 멀티 환경 고민 필요
-    public String generate() {
+    public OrderNo generate() {
         int l = ByteBuffer
             .wrap(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8))
             .getInt();
 
-        return Integer.toString(l, LENGTH_10_INT_RADIX);
+        return new OrderNo(Integer.toString(l, LENGTH_10_INT_RADIX));
     }
 }

--- a/src/main/java/com/example/demo/core/order/domain/Order.java
+++ b/src/main/java/com/example/demo/core/order/domain/Order.java
@@ -3,6 +3,7 @@ package com.example.demo.core.order.domain;
 import com.example.demo.config.persistence.AuditEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -29,8 +30,8 @@ public class Order extends AuditEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long orderId;
 
-    @Column(name = "order_no", nullable = false, updatable = false, unique = true)
-    private String orderNo;
+    @Embedded
+    private OrderNo orderNo;
 
     @Column(name = "member_no", nullable = false, updatable = false)
     private long memberNo;
@@ -44,7 +45,7 @@ public class Order extends AuditEntity {
     @OneToMany(fetch = LAZY, cascade = {CascadeType.PERSIST}, mappedBy = "order")
     private Set<OrderProduct> products = new LinkedHashSet<>();
 
-    public Order(String orderNo,
+    public Order(OrderNo orderNo,
                  long memberNo,
                  String orderName,
                  BigDecimal transactionAmount) {

--- a/src/main/java/com/example/demo/core/order/domain/OrderNo.java
+++ b/src/main/java/com/example/demo/core/order/domain/OrderNo.java
@@ -1,0 +1,24 @@
+package com.example.demo.core.order.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderNo {
+    @Column(name = "order_no", nullable = false, updatable = false, unique = true)
+    private String value;
+
+    public OrderNo(final String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("OrderNo cannot be null or empty");
+        }
+        this.value = value;
+    }
+}

--- a/src/main/java/com/example/demo/core/order/result/CreateOrderResult.java
+++ b/src/main/java/com/example/demo/core/order/result/CreateOrderResult.java
@@ -1,6 +1,7 @@
 package com.example.demo.core.order.result;
 
 import com.example.demo.core.order.domain.Order;
+import com.example.demo.core.order.domain.OrderNo;
 import com.example.demo.core.order.domain.OrderProduct;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -9,7 +10,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record CreateOrderResult(@NotEmpty String orderNo,
+public record CreateOrderResult(@NotNull OrderNo orderNo,
                                 long memberNo,
                                 @NotEmpty String orderName,
                                 @NotNull BigDecimal transactionAmount,

--- a/src/main/java/com/example/demo/core/order/service/CreateOrderService.java
+++ b/src/main/java/com/example/demo/core/order/service/CreateOrderService.java
@@ -2,6 +2,7 @@ package com.example.demo.core.order.service;
 
 import com.example.demo.common.utils.OrderNoGenerator;
 import com.example.demo.core.order.domain.Order;
+import com.example.demo.core.order.domain.OrderNo;
 import com.example.demo.core.order.domain.OrderProduct;
 import com.example.demo.core.order.param.CreateOrderParam;
 import com.example.demo.core.order.result.CreateOrderResult;
@@ -22,7 +23,7 @@ public class CreateOrderService {
 
     @Transactional
     public CreateOrderResult create(final CreateOrderParam param) {
-        final String orderNo = orderNoGenerator.generate();
+        final OrderNo orderNo = orderNoGenerator.generate();
 
         final Order order = new Order(
             orderNo,

--- a/src/main/java/com/example/demo/web/v1/order/OrderController.java
+++ b/src/main/java/com/example/demo/web/v1/order/OrderController.java
@@ -9,17 +9,19 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/v1/orders")
 @RequiredArgsConstructor
-public class CreateOrderController {
+public class OrderController {
 
     private final CreateOrderService createOrderService;
 
-    @PostMapping("/v1/order")
-    public ApiResponse<CreateOrderResponse> create(@RequestBody @Valid CreateOrderRequest request) {
-        CreateOrderResult result = createOrderService.create(request.toParam());
+    @PostMapping
+    public ApiResponse<CreateOrderResponse> create(@Valid @RequestBody CreateOrderRequest request) {
+        final CreateOrderResult result = createOrderService.create(request.toParam());
 
         return ApiResponse.success(CreateOrderResponse.from(result));
     }

--- a/src/main/java/com/example/demo/web/v1/order/response/CreateOrderResponse.java
+++ b/src/main/java/com/example/demo/web/v1/order/response/CreateOrderResponse.java
@@ -18,7 +18,7 @@ public record CreateOrderResponse(@NotNull String orderNo,
 
     public static CreateOrderResponse from(final CreateOrderResult result) {
         return new CreateOrderResponse(
-            result.orderNo(),
+            result.orderNo().getValue(),
             result.memberNo(),
             result.orderName(),
             result.transactionAmount(),

--- a/src/test/java/com/example/demo/TestFixtures.java
+++ b/src/test/java/com/example/demo/TestFixtures.java
@@ -20,9 +20,9 @@ public class TestFixtures {
             .enableLoggingFail(false)
             .objectIntrospector(new FailoverIntrospector(
                 List.of(
-                    ConstructorPropertiesArbitraryIntrospector.INSTANCE,
-                    BuilderArbitraryIntrospector.INSTANCE,
                     FieldReflectionArbitraryIntrospector.INSTANCE,
+                    BuilderArbitraryIntrospector.INSTANCE,
+                    ConstructorPropertiesArbitraryIntrospector.INSTANCE,
                     BeanArbitraryIntrospector.INSTANCE
                 )
             ))

--- a/src/test/java/com/example/demo/common/utils/OrderNoGeneratorTest.java
+++ b/src/test/java/com/example/demo/common/utils/OrderNoGeneratorTest.java
@@ -1,16 +1,15 @@
 package com.example.demo.common.utils;
 
 import com.example.demo.annotation.UnitTest;
+import com.example.demo.core.order.domain.OrderNo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
-import static com.example.demo.MemberFixtures.MEMBER_ID;
-import static com.example.demo.MemberFixtures.MEMBER_NAME;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @UnitTest
+@DisplayName("OrderNoGenerator")
 class OrderNoGeneratorTest {
 
     private final OrderNoGenerator orderNoGenerator = new OrderNoGenerator();
@@ -28,10 +27,10 @@ class OrderNoGeneratorTest {
             @Test
             @DisplayName("랜덤 10자리 문자열을 리턴한다.")
             void it() {
-                String orderNo = orderNoGenerator.generate();
+                final OrderNo actual = orderNoGenerator.generate();
 
-                assertNotNull(orderNo);
-                assertEquals(orderNoLength, orderNo.length());
+                assertThat(actual).isNotNull();
+                assertThat(actual.getValue()).hasSize(orderNoLength);
             }
         }
     }

--- a/src/test/java/com/example/demo/core/order/domain/OrderNoTest.java
+++ b/src/test/java/com/example/demo/core/order/domain/OrderNoTest.java
@@ -1,0 +1,23 @@
+package com.example.demo.core.order.domain;
+
+import com.example.demo.annotation.UnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@UnitTest
+@DisplayName("OrderNo")
+class OrderNoTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { " ", "   ", "\t", "\n" })
+    @NullAndEmptySource
+    @DisplayName("주문번호는 NULL 또는 공백일 때 IllegalArgumentException()을 던진다.")
+    void test1(String value) {
+        assertThatThrownBy(() -> new OrderNo(value))
+            .isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/example/demo/core/order/service/CreateOrderServiceTest.java
+++ b/src/test/java/com/example/demo/core/order/service/CreateOrderServiceTest.java
@@ -4,6 +4,7 @@ import com.example.demo.TestFixtures;
 import com.example.demo.annotation.IntegrationTest;
 import com.example.demo.common.utils.OrderNoGenerator;
 import com.example.demo.core.order.domain.Order;
+import com.example.demo.core.order.domain.OrderNo;
 import com.example.demo.core.order.param.CreateOrderParam;
 import com.example.demo.core.order.result.CreateOrderResult;
 import com.example.demo.infrastructure.persistence.order.OrderRepository;
@@ -21,7 +22,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import java.math.BigDecimal;
 
 import static com.example.demo.OrderFixtures.ORDER_NO;
-import static com.navercorp.fixturemonkey.api.instantiator.Instantiator.constructor;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
@@ -52,7 +52,7 @@ class CreateOrderServiceTest {
     @Nested
     @DisplayName("create 메소드는")
     class Describe_create {
-        private final String orderNo = ORDER_NO;
+        private final OrderNo orderNo = ORDER_NO;
 
         final CreateOrderParam param = TestFixtures.get()
             .giveMeBuilder(CreateOrderParam.class)
@@ -89,23 +89,18 @@ class CreateOrderServiceTest {
             void setUp() {
                 final Order order = TestFixtures.get()
                     .giveMeBuilder(Order.class)
-                    .instantiate(
-                        constructor()
-                            .parameter(String.class)
-                            .parameter(long.class)
-                            .parameter(String.class)
-                            .parameter(BigDecimal.class)
-                    )
+                    .setNull("orderId")
                     .set("orderNo", orderNo)
-                    .setNotNull("orderName")
+                    .set("orderName", "XXXXX")
                     .set("transactionAmount", BigDecimal.ONE)
+                    .size("products", 0)
                     .sample();
 
                 orderRepository.saveAndFlush(order);
             }
 
             @Test
-            @DisplayName("DataIntegrityViolationException을 던진다.")
+            @DisplayName("DataIntegrityViolationException()을 던진다.")
             void it() {
                 assertThrows(DataIntegrityViolationException.class, () -> {
                     createOrderService.create(param);

--- a/src/test/java/com/example/demo/core/order/service/CreateOrderServiceTest.java
+++ b/src/test/java/com/example/demo/core/order/service/CreateOrderServiceTest.java
@@ -91,7 +91,7 @@ class CreateOrderServiceTest {
                     .giveMeBuilder(Order.class)
                     .setNull("orderId")
                     .set("orderNo", orderNo)
-                    .set("orderName", "XXXXX")
+                    .setNotNull("orderName")
                     .set("transactionAmount", BigDecimal.ONE)
                     .size("products", 0)
                     .sample();

--- a/src/test/java/com/example/demo/core/order/service/CreateOrderServiceTest.java
+++ b/src/test/java/com/example/demo/core/order/service/CreateOrderServiceTest.java
@@ -22,8 +22,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import java.math.BigDecimal;
 
 import static com.example.demo.OrderFixtures.ORDER_NO;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
 @IntegrationTest
@@ -102,9 +102,8 @@ class CreateOrderServiceTest {
             @Test
             @DisplayName("DataIntegrityViolationException()을 던진다.")
             void it() {
-                assertThrows(DataIntegrityViolationException.class, () -> {
-                    createOrderService.create(param);
-                });
+                assertThatThrownBy(() -> createOrderService.create(param))
+                    .isExactlyInstanceOf(DataIntegrityViolationException.class);
             }
         }
     }

--- a/src/testFixtures/java/com/example/demo/OrderFixtures.java
+++ b/src/testFixtures/java/com/example/demo/OrderFixtures.java
@@ -1,7 +1,9 @@
 package com.example.demo;
 
+import com.example.demo.core.order.domain.OrderNo;
+
 public class OrderFixtures {
     private OrderFixtures() {}
 
-    public static final String ORDER_NO = "2311604346";
+    public static final OrderNo ORDER_NO = new OrderNo("2311604346");
 }


### PR DESCRIPTION
주문번호를 String에서 value object로 적용한 PR

코틀린에서는 Jpa 엔티티에 `value class`로 쉽게 적용했는데, 자바에서는 `@Embedded`을 선언하는 등 다소 손이 많이 갔음
FixtureMonkey의 객체 생성 방식과 Jpa 엔티티에 `@NoArgsConstructor(access = AccessLevel.PROTECTED)`를 선언해야 하는 이유를 알 수 있었던 PR