### PR TITLE
Feature/rfc 9457

### DIFF
--- a/src/main/java/com/example/demo/config/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/config/handler/GlobalExceptionHandler.java
@@ -1,24 +1,60 @@
 package com.example.demo.config.handler;
 
-import com.example.demo.web.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-    private static final String DEFAULT_INTERNAL_SERVER_ERR_MSG = "알 수 없는 에러가 발생했습니다. 관리자에게 문의하세요.";
-    private static final String DEFAULT_BAD_REQUEST_ERR_MSG = "잘못된 요청입니다. 요청내용을 확인하세요.";
+    private static final String DEFAULT_INTERNAL_SERVER_ERR_MESSAGE = "알 수 없는 에러가 발생했습니다. 관리자에게 문의하세요.";
+    private static final String DEFAULT_BAD_REQUEST_ERR_MESSAGE = "잘못된 요청입니다. 요청내용을 확인하세요.";
 
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
-    protected ApiResponse<Void> handle(Exception exception) {
+    protected ResponseEntity<Object> handle(Exception exception) {
         log.error(exception.getMessage(), exception);
 
-        return ApiResponse.fail("500", DEFAULT_INTERNAL_SERVER_ERR_MSG);
+        final ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(INTERNAL_SERVER_ERROR, DEFAULT_INTERNAL_SERVER_ERR_MESSAGE);
+        problemDetail.setProperty("timestamp", Instant.now());
+
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(problemDetail);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers,
+                                                                  HttpStatusCode status,
+                                                                  WebRequest request) {
+
+        final ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(ex.getStatusCode(), getErrorsDetails(ex));
+        problemDetail.setType(URI.create("http://localhost:8080/errors/bad-request"));
+        problemDetail.setProperty("timestamp", Instant.now());
+
+        return ResponseEntity.status(status.value()).body(problemDetail);
+    }
+
+    private String getErrorsDetails(MethodArgumentNotValidException ex) {
+        return Optional.of(ex.getDetailMessageArguments())
+            .map(args -> Arrays.stream(args)
+                .filter(msg -> !ObjectUtils.isEmpty(msg))
+                .reduce("Please make sure to provide a valid request, ", (a, b) -> a + " " + b)
+            )
+            .orElse("").toString();
     }
 }

--- a/src/main/java/com/example/demo/web/v1/member/CreateMemberController.java
+++ b/src/main/java/com/example/demo/web/v1/member/CreateMemberController.java
@@ -6,18 +6,16 @@ import com.example.demo.web.ApiResponse;
 import com.example.demo.web.v1.member.request.CreateMemberRequest;
 import com.example.demo.web.v1.member.response.CreateMemberResponse;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class CreateMemberController {
 
     private final CreateMemberService createMemberService;
-
-    public CreateMemberController(CreateMemberService createMemberService) {
-        this.createMemberService = createMemberService;
-    }
 
     @PostMapping("/v1/member")
     public ApiResponse<CreateMemberResponse> create(@RequestBody @Valid CreateMemberRequest request) {

--- a/src/main/java/com/example/demo/web/v1/member/request/CreateMemberRequest.java
+++ b/src/main/java/com/example/demo/web/v1/member/request/CreateMemberRequest.java
@@ -3,12 +3,17 @@ package com.example.demo.web.v1.member.request;
 import com.example.demo.core.member.param.CreateMemberParam;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
-
-public record CreateMemberRequest(@NotEmpty String memberId,
-                                  @NotEmpty String memberName,
-                                  @Email String email) {
-
+public record CreateMemberRequest(
+    @NotEmpty
+    String memberId,
+    @NotEmpty
+    String memberName,
+    @Email(message = "유효하지 않은 이메일 포맷입니다.")
+    @NotNull
+    String email
+) {
     public CreateMemberParam toParam() {
         return new CreateMemberParam(memberId, memberName, email);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,9 @@ spring:
     type: caffeine
   caffeine:
     spec: maximumSize=100,expireAfterWrite=1m
+  mvc:
+    problemdetails:
+      enabled: true
 
 management:
   tracing:


### PR DESCRIPTION
RFC-9457 규격 반영 PR
https://www.rfc-editor.org/rfc/rfc9457.html

RFC-9457은 RESTful API에서 에러 응답을 위한 공통 포맷을 정의하는 새로운 표준
```
{
    // 필수 필드
    "type": "http://localhost:8080/errors/bad-request", // 문제 유형을 식별하는 URI 참조
    "title": "Bad Request", // 문제 유형에 대한 간단하고 사람이 읽을 수 있는 요약 문자열
    "status": 400, // 이 문제에 대해 서버가 반환한 HTTP 상태 코드
    "detail": "Please make sure to provide a valid request,  email: 유효하지 않은 이메일 포맷입니다.", // 이 문제 발생에 대한 자세하고 구체적인 설명

    // 옵션 필드
    "instance": "/v1/member", // 문제가 발생한 요청 URI
    "timestamp": "2025-06-02T12:19:16.352722Z"
}
```

`ResponseEntityExceptionHandler`에 정의된 익셉션은 익셉션 핸들러를 오버라이드 해서 사용 가능
ex) HandlerMethodValidationException은 handleMethodArgumentNotValid()를 오버라이드 해서 사용

`@ExceptionHandler(Exception.class)`을 대체하기 위한 익셉션 핸들러는 `ResponseEntityExceptionHandler` 정의되지 않아서 기존 방식대로 해야하는 듯

참고 링크
https://www.baeldung.com/spring-boot-return-errors-problemdetail
https://abdelrani.com/blog/the-standard-way-for-handling-error-responses-in-spring-web
https://luvstudy.tistory.com/220