### PR TITLE
Feature/test serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.3'
     testImplementation 'org.mockito:mockito-core:5.13.0'
     testImplementation 'io.github.resilience4j:resilience4j-test:2.2.0'
+    testImplementation 'org.junit-pioneer:junit-pioneer:2.3.0'
 
     testRuntimeOnly 'com.h2database:h2'
     testFixturesImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.3'

--- a/src/test/java/com/example/etc/serialization/SerializationFailTest.java
+++ b/src/test/java/com/example/etc/serialization/SerializationFailTest.java
@@ -1,0 +1,122 @@
+package com.example.etc.serialization;
+
+import com.example.etc.serialization.fail.Fail1;
+import com.example.etc.serialization.fail.Fail2;
+import com.example.etc.serialization.fail.Fail3;
+import com.example.etc.serialization.fail.Fail4;
+import com.example.etc.serialization.fail.Fail5;
+import com.example.etc.serialization.fail.Fail6;
+import com.example.etc.serialization.fail.Fail7;
+import com.example.etc.serialization.fail.Fail8;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.StdIo;
+import org.junitpioneer.jupiter.StdOut;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SerializationFailTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void init() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    @StdIo
+    @DisplayName("record + inner record + get() 조합: get()를 호출하면서 직렬화 시도")
+    void test1(StdOut stdOut) {
+        final Fail1 sut = new Fail1("1.9,3.5,10.3");
+
+        assertThatThrownBy(() -> objectMapper.writeValueAsString(sut))
+            .isExactlyInstanceOf(JsonMappingException.class);
+
+        assertThat(stdOut.capturedLines()[0]).isEqualTo("get() 호출");
+    }
+
+    @Test
+    @StdIo
+    @DisplayName("record + inner record + get() 조합: get()를 호출하면서 직렬화 시도, inner record 명인 'Package' 문제는 아님")
+    void test2(StdOut stdOut) {
+        final Fail2 sut = new Fail2("1.9,3.5,10.3");
+
+        assertThatThrownBy(() -> objectMapper.writeValueAsString(sut))
+            .isExactlyInstanceOf(JsonMappingException.class);
+
+        assertThat(stdOut.capturedLines()[0]).isEqualTo("get() 호출");
+    }
+
+    @Test
+    @StdIo
+    @DisplayName("record + inner record + get() 조합: get()를 호출하면서 직렬화 시도, 'Serializable' 구현 문제는 아님")
+    void test3(StdOut stdOut) {
+        final Fail3 sut = new Fail3("1.9,3.5,10.3");
+
+        assertThatThrownBy(() -> objectMapper.writeValueAsString(sut))
+            .isExactlyInstanceOf(JsonMappingException.class);
+
+        assertThat(stdOut.capturedLines()[0]).isEqualTo("get() 호출");
+    }
+
+    @Test
+    @StdIo
+    @DisplayName("class + inner record + get() 조합: get()를 호출하면서 직렬화 시도")
+    void test4(StdOut stdOut) {
+        final Fail4 sut = new Fail4("1.9,3.5,10.3");
+
+        assertThatThrownBy(() -> objectMapper.writeValueAsString(sut))
+            .isExactlyInstanceOf(JsonMappingException.class);
+
+        assertThat(stdOut.capturedLines()[0]).isEqualTo("get() 호출");
+    }
+
+    @Test
+    @DisplayName("class + inner record 조합: values 필드의 getter가 없어서 직렬화 실패")
+    void test5() {
+        final Fail5 sut = new Fail5("1.9,3.5,10.3");
+
+        assertThatThrownBy(() -> objectMapper.writeValueAsString(sut))
+            .isExactlyInstanceOf(InvalidDefinitionException.class);
+    }
+
+    @Test
+    @StdIo
+    @DisplayName("class + inner class + get() 조합: get()를 호출하면서 inner class부터 직렬화 시도")
+    void test6(StdOut stdOut) {
+        final Fail6 sut = new Fail6("1.9,3.5,10.3");
+
+        assertThatThrownBy(() -> objectMapper.writeValueAsString(sut))
+            .isExactlyInstanceOf(JsonMappingException.class);
+
+        assertThat(stdOut.capturedLines()[0]).isEqualTo("get() 호출");
+    }
+
+    @Test
+    @DisplayName("class + inner class 조합: values 필드의 getter가 없어서 직렬화 실패")
+    void test7() {
+        final Fail7 sut = new Fail7("1.9,3.5,10.3");
+
+        assertThatThrownBy(() -> objectMapper.writeValueAsString(sut))
+            .isExactlyInstanceOf(InvalidDefinitionException.class);
+    }
+
+
+    @Test
+    @StdIo
+    @DisplayName("class + inner class 조합 + get() 조합: values 필드의 getter가 없어서 직렬화 실패, inner class의 get()을 호출하진 않음")
+    void test8(StdOut stdOut) {
+        final Fail8 sut = new Fail8("1.9,3.5,10.3");
+
+        assertThatThrownBy(() -> objectMapper.writeValueAsString(sut))
+            .isExactlyInstanceOf(InvalidDefinitionException.class);
+
+        assertThat(stdOut.capturedLines()).isEmpty();
+    }
+}

--- a/src/test/java/com/example/etc/serialization/SerializationSuccessTest.java
+++ b/src/test/java/com/example/etc/serialization/SerializationSuccessTest.java
@@ -1,0 +1,65 @@
+package com.example.etc.serialization;
+
+import com.example.etc.serialization.sucess.Success1;
+import com.example.etc.serialization.sucess.Success2;
+import com.example.etc.serialization.sucess.Success3;
+import com.example.etc.serialization.sucess.Success4;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class SerializationSuccessTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void init() {
+        objectMapper = new ObjectMapper();
+    }
+
+
+    @Test
+    @DisplayName("record + inner record 조합: 문제없음")
+    void test1() {
+        final Success1 sut = new Success1("1.9,3.5,10.3");
+
+        final String actual = assertDoesNotThrow(() -> objectMapper.writeValueAsString(sut));
+
+        System.out.println(actual);
+    }
+
+    @Test
+    @DisplayName("record + inner class 조합: 문제 없음")
+    void test2() {
+        final Success2 sut = new Success2("1.9,3.5,10.3");
+
+        final String actual = assertDoesNotThrow(() -> objectMapper.writeValueAsString(sut));
+
+        System.out.println(actual);
+    }
+
+    @Test
+    @DisplayName("class + inner class + @JsonProperty 조합: 문제 없음")
+    void test3() {
+        final Success3 sut = new Success3("1.9,3.5,10.3");
+
+        final String actual = assertDoesNotThrow(() -> objectMapper.writeValueAsString(sut));
+
+        System.out.println(actual);
+    }
+
+    @Test
+    @DisplayName("class + inner class + FAIL_ON_EMPTY_BEANS 옵션 조합: 문제 없음")
+    void test4() {
+        final Success4 sut = new Success4("1.9,3.5,10.3");
+        objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+
+        final String actual = assertDoesNotThrow(() -> objectMapper.writeValueAsString(sut));
+
+        System.out.println(actual);
+    }
+}

--- a/src/test/java/com/example/etc/serialization/SerializationSuccessTest.java
+++ b/src/test/java/com/example/etc/serialization/SerializationSuccessTest.java
@@ -4,12 +4,16 @@ import com.example.etc.serialization.sucess.Success1;
 import com.example.etc.serialization.sucess.Success2;
 import com.example.etc.serialization.sucess.Success3;
 import com.example.etc.serialization.sucess.Success4;
+import com.example.etc.serialization.sucess.Success5;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.StdIo;
+import org.junitpioneer.jupiter.StdOut;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class SerializationSuccessTest {
@@ -59,6 +63,19 @@ public class SerializationSuccessTest {
         objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 
         final String actual = assertDoesNotThrow(() -> objectMapper.writeValueAsString(sut));
+
+        System.out.println(actual);
+    }
+
+    @Test
+    @StdIo
+    @DisplayName("class + get() + inner class 조합: 문제 없음")
+    void test5(StdOut stdOut) {
+        final Success5 sut = new Success5("1.9,3.5,10.3");
+
+        final String actual = assertDoesNotThrow(() -> objectMapper.writeValueAsString(sut));
+
+        assertThat(stdOut.capturedLines()[0]).isEqualTo("getValues() 호출");
 
         System.out.println(actual);
     }

--- a/src/test/java/com/example/etc/serialization/fail/Fail1.java
+++ b/src/test/java/com/example/etc/serialization/fail/Fail1.java
@@ -1,0 +1,24 @@
+package com.example.etc.serialization.fail;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public record Fail1(
+    String values
+) implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -1446398935944895849L;
+
+    public record Package(
+        int value1,
+        int value2
+    ) {}
+
+    public Package getPackage() {
+        String[] data = values.split(",");
+
+        System.out.println("get() 호출");
+
+        return new Package(Integer.parseInt(data[0]), Integer.parseInt(data[1]));
+    }
+}

--- a/src/test/java/com/example/etc/serialization/fail/Fail2.java
+++ b/src/test/java/com/example/etc/serialization/fail/Fail2.java
@@ -1,0 +1,24 @@
+package com.example.etc.serialization.fail;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public record Fail2(
+    String values
+) implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -1446398935944895849L;
+
+    public record Book(
+        int value1,
+        int value2
+    ) {}
+
+    public Book getBook() {
+        String[] data = values.split(",");
+
+        System.out.println("get() 호출");
+
+        return new Book(Integer.parseInt(data[0]), Integer.parseInt(data[1]));
+    }
+}

--- a/src/test/java/com/example/etc/serialization/fail/Fail3.java
+++ b/src/test/java/com/example/etc/serialization/fail/Fail3.java
@@ -1,0 +1,18 @@
+package com.example.etc.serialization.fail;
+
+public record Fail3(
+    String values
+) {
+    public record Book(
+        int value1,
+        int value2
+    ) {}
+
+    public Book getBook() {
+        String[] data = values.split(",");
+
+        System.out.println("get() 호출");
+
+        return new Book(Integer.parseInt(data[0]), Integer.parseInt(data[1]));
+    }
+}

--- a/src/test/java/com/example/etc/serialization/fail/Fail4.java
+++ b/src/test/java/com/example/etc/serialization/fail/Fail4.java
@@ -1,0 +1,23 @@
+package com.example.etc.serialization.fail;
+
+public class Fail4 {
+
+    private final String values;
+
+    public record Book(
+        int value1,
+        int value2
+    ) {}
+
+    public Book getBook() {
+        String[] data = values.split(",");
+
+        System.out.println("get() 호출");
+
+        return new Book(Integer.parseInt(data[0]), Integer.parseInt(data[1]));
+    }
+
+    public Fail4(String values) {
+        this.values = values;
+    }
+}

--- a/src/test/java/com/example/etc/serialization/fail/Fail5.java
+++ b/src/test/java/com/example/etc/serialization/fail/Fail5.java
@@ -1,0 +1,15 @@
+package com.example.etc.serialization.fail;
+
+public class Fail5 {
+
+    private final String values;
+
+    public record Book(
+        int value1,
+        int value2
+    ) {}
+
+    public Fail5(String values) {
+        this.values = values;
+    }
+}

--- a/src/test/java/com/example/etc/serialization/fail/Fail6.java
+++ b/src/test/java/com/example/etc/serialization/fail/Fail6.java
@@ -1,0 +1,28 @@
+package com.example.etc.serialization.fail;
+
+public class Fail6 {
+
+    private final String values;
+
+    public static class Book {
+        private final int value1;
+        private final int value2;
+
+        public Book(int value1, int value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+        }
+    }
+
+    public Book getBook() {
+        String[] data = values.split(",");
+
+        System.out.println("get() 호출");
+
+        return new Book(Integer.parseInt(data[0]), Integer.parseInt(data[1]));
+    }
+
+    public Fail6(String values) {
+        this.values = values;
+    }
+}

--- a/src/test/java/com/example/etc/serialization/fail/Fail7.java
+++ b/src/test/java/com/example/etc/serialization/fail/Fail7.java
@@ -1,0 +1,20 @@
+package com.example.etc.serialization.fail;
+
+public class Fail7 {
+
+    private final String values;
+
+    public static class Book {
+        private final int value1;
+        private final int value2;
+
+        public Book(int value1, int value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+        }
+    }
+
+    public Fail7(String values) {
+        this.values = values;
+    }
+}

--- a/src/test/java/com/example/etc/serialization/fail/Fail8.java
+++ b/src/test/java/com/example/etc/serialization/fail/Fail8.java
@@ -1,0 +1,30 @@
+package com.example.etc.serialization.fail;
+
+public class Fail8 {
+
+    private final String values;
+
+    public static class Book {
+        private final int value1;
+        private final int value2;
+
+        public Book(int value1, int value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+        }
+
+        public int getValue1() {
+            System.out.println("getValue1() 호출");
+            return value1;
+        }
+
+        public int getValue2() {
+            System.out.println("getValue2() 호출");
+            return value2;
+        }
+    }
+
+    public Fail8(String values) {
+        this.values = values;
+    }
+}

--- a/src/test/java/com/example/etc/serialization/sucess/Success1.java
+++ b/src/test/java/com/example/etc/serialization/sucess/Success1.java
@@ -1,0 +1,10 @@
+package com.example.etc.serialization.sucess;
+
+public record Success1(
+    String values
+) {
+    public record Book(
+        int value1,
+        int value2
+    ) {}
+}

--- a/src/test/java/com/example/etc/serialization/sucess/Success2.java
+++ b/src/test/java/com/example/etc/serialization/sucess/Success2.java
@@ -1,0 +1,15 @@
+package com.example.etc.serialization.sucess;
+
+public record Success2(
+    String values
+) {
+    public static class Book {
+        private final int value1;
+        private final int value2;
+
+        public Book(int value1, int value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+        }
+    }
+}

--- a/src/test/java/com/example/etc/serialization/sucess/Success3.java
+++ b/src/test/java/com/example/etc/serialization/sucess/Success3.java
@@ -1,0 +1,23 @@
+package com.example.etc.serialization.sucess;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Success3 {
+
+    @JsonProperty
+    private final String values;
+
+    public static class Book {
+        private final int value1;
+        private final int value2;
+
+        public Book(int value1, int value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+        }
+    }
+
+    public Success3(String values) {
+        this.values = values;
+    }
+}

--- a/src/test/java/com/example/etc/serialization/sucess/Success4.java
+++ b/src/test/java/com/example/etc/serialization/sucess/Success4.java
@@ -1,0 +1,20 @@
+package com.example.etc.serialization.sucess;
+
+public class Success4 {
+
+    private final String values;
+
+    public static class Book {
+        private final int value1;
+        private final int value2;
+
+        public Book(int value1, int value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+        }
+    }
+
+    public Success4(String values) {
+        this.values = values;
+    }
+}

--- a/src/test/java/com/example/etc/serialization/sucess/Success5.java
+++ b/src/test/java/com/example/etc/serialization/sucess/Success5.java
@@ -1,0 +1,25 @@
+package com.example.etc.serialization.sucess;
+
+public class Success5 {
+
+    private final String values;
+
+    public static class Book {
+        private final int value1;
+        private final int value2;
+
+        public Book(int value1, int value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+        }
+    }
+
+    public Success5(String values) {
+        this.values = values;
+    }
+
+    public String getValues() {
+        System.out.println("getValues() 호출");
+        return values;
+    }
+}


### PR DESCRIPTION
예상치 못 한 Json 직렬화 이슈 경험

```
record Outer(
  String values
) implements Serializable {
  @Serial
  private static final long serialVersionUID = -1446398935944895849L;

  record Inner() {}

  public Inner getInner() {}
}
```
위와 같이 Outer 내부에 Inner가 존재하지만, Inner는 필드로 선언되어 있지 않은 상황
`ObjectMapper.writeValueAsString()`로 Outer를 직렬화하는 코드에서 뜬금 없이 Inner 직렬화를 시도하다가 실패하는 오류 발생
에러 로그 확인 시 `getInner()`를 호출하여 Inner 직렬화를 시도하는 점 확인

무엇이 문제인지 테스트 케이스를 작성해가며 추적해본 PR

1. `Serializable`는 범인이 아님
2. Inner 클래스명인 `Package`는 범인이 아님 (gpt가 Package라는 클래스명(키워드)이 문제일 수 있다고 언급)
3. 범인은 getInner() 메소드. Inner가 필드로 선언되어 있지 않아도 ObjectMapper는 getter()로 인식하고 직렬화를 시도함
4. `@JsonProperty`와 `@JsonIgnore`를 선언하여 직렬화 대상을 제어할 수 있음
5. ObjectMapper의 `FAIL_ON_EMPTY_BEANS`를 비활성화하여 직렬화 대상이 없거나 getter()가 없을 때 예외를 던지지 않도록 할 수 있음. 클래스에 문제가 있을 때 예외가 발생하지 않아 문제 확인이 어려운 단점 존재


---

~~현업 코드에는 전역적으로 ObjectMapper의 `FAIL_ON_EMPTY_BEANS`를 비활성화하고 있는데도, 직렬화를 시도했다는 점은 더 확인해봐야할 듯
Json을 직렬화하는 클래스에서 ObjectMapper를 주입받고 있는데, 주입받는 ObjectMapper가 다른 ObjectMapper인건지?~~

`FAIL_ON_EMPTY_BEANS` 비활성화는 직렬화 대상이 없거나 getter()가 없을 때 예외를 발생하지 않는 설정으로 해결책은 아닌 것으로 확인