### PR TITLE
Feature/version up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,8 @@ dependencies {
 
     implementation 'org.springframework.kafka:spring-kafka'
 
-    // 2.3.0 버전 사용 시 Bean 이슈 발생
+    // 2.3.0 버전 사용 시 RxJava3FallbackDecorator ClassNotFoundException 발생
+    // https://github.com/resilience4j/resilience4j/issues/2265
 //    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.3.0'
     implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:5.13.0'
     testImplementation 'io.github.resilience4j:resilience4j-test:2.2.0'
     testImplementation 'org.junit-pioneer:junit-pioneer:2.3.0'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     testRuntimeOnly 'com.h2database:h2'
     testFixturesImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.14'

--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,9 @@ dependencies {
 
     implementation 'org.springframework.kafka:spring-kafka'
 
-    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.3.0'
-//    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+    // 2.3.0 버전 사용 시 Bean 이슈 발생
+//    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.3.0'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.5'
-	id 'io.spring.dependency-management' version '1.1.6'
+	id 'org.springframework.boot' version '3.5.4'
+	id 'io.spring.dependency-management' version '1.1.7'
     id 'java-test-fixtures'
 }
 
@@ -26,7 +26,7 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', "2023.0.3")
+    set('springCloudVersion', "2025.0.0")
 }
 
 dependencyManagement {
@@ -51,7 +51,7 @@ dependencies {
 
     implementation 'org.springframework.kafka:spring-kafka'
 
-    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.3.0'
 //    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 
     implementation 'org.springframework.boot:spring-boot-starter-cache'
@@ -68,13 +68,13 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.1'
-    testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.3'
+    testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.14'
     testImplementation 'org.mockito:mockito-core:5.13.0'
     testImplementation 'io.github.resilience4j:resilience4j-test:2.2.0'
     testImplementation 'org.junit-pioneer:junit-pioneer:2.3.0'
 
     testRuntimeOnly 'com.h2database:h2'
-    testFixturesImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.3'
+    testFixturesImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.14'
 }
 
 tasks.named('test') {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/java/com/example/demo/DummyEntity.java
+++ b/src/test/java/com/example/demo/DummyEntity.java
@@ -1,0 +1,16 @@
+package com.example.demo;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DummyEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/test/java/com/example/demo/TestTransactionEventSupport.java
+++ b/src/test/java/com/example/demo/TestTransactionEventSupport.java
@@ -1,0 +1,23 @@
+package com.example.demo;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class TestTransactionEventSupport {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final EntityManager entityManager;
+
+    public void publish(final Object event) {
+        entityManager.persist(new DummyEntity());
+        applicationEventPublisher.publishEvent(event);
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/com/example/demo/annotation/TransactionalEventListenerTest.java
+++ b/src/test/java/com/example/demo/annotation/TransactionalEventListenerTest.java
@@ -1,0 +1,17 @@
+package com.example.demo.annotation;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.event.RecordApplicationEvents;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest
+@TestEnvironment
+@RecordApplicationEvents
+public @interface TransactionalEventListenerTest {
+}

--- a/src/test/java/com/example/demo/core/member/event/MemberEventListenerTest.java
+++ b/src/test/java/com/example/demo/core/member/event/MemberEventListenerTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -24,7 +24,7 @@ class MemberEventListenerTest {
     private ApplicationEventPublisher applicationEventPublisher;
     @InjectMocks
     private MemberEventListener memberEventListener;
-    @MockBean
+    @MockitoBean
     private SendMemberEmailService sendMemberEmailService;
 
     @Test

--- a/src/test/java/com/example/demo/core/member/event/MemberEventListenerTest.java
+++ b/src/test/java/com/example/demo/core/member/event/MemberEventListenerTest.java
@@ -1,27 +1,26 @@
 package com.example.demo.core.member.event;
 
 import com.example.demo.TestFixtures;
-import com.example.demo.annotation.EventListenerTest;
+import com.example.demo.TestTransactionEventSupport;
+import com.example.demo.annotation.TransactionalEventListenerTest;
 import com.example.demo.core.member.param.SendMemberEmailParam;
 import com.example.demo.core.member.service.SendMemberEmailService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
-@EventListenerTest(classes = { ApplicationEventPublisher.class, MemberEventListener.class })
+@TransactionalEventListenerTest
 @DisplayName("MemberEventListener")
 class MemberEventListenerTest {
-
     @Autowired
-    private ApplicationEventPublisher applicationEventPublisher;
+    private TestTransactionEventSupport support;
     @InjectMocks
     private MemberEventListener memberEventListener;
     @MockitoBean
@@ -29,14 +28,14 @@ class MemberEventListenerTest {
 
     @Test
     @DisplayName("createMember()는 회원가입 이벤트가 발생했을 때 이메일을 전송한다.")
-    void createMember_when_publish_CreateMemberEvent_then_send_email() {
+    void test1() {
         final CreateMemberEvent event = TestFixtures.get()
             .giveMeOne(CreateMemberEvent.class);
         doNothing().when(sendMemberEmailService).createMemberEmail(any(SendMemberEmailParam.class));
 
-        applicationEventPublisher.publishEvent(event);
+        support.publish(event);
 
-        verify(sendMemberEmailService, times(1))
+        verify(sendMemberEmailService, timeout(2000))
             .createMemberEmail(any(SendMemberEmailParam.class));
     }
 }

--- a/src/test/java/com/example/demo/core/member/service/CreateMemberServiceTest.java
+++ b/src/test/java/com/example/demo/core/member/service/CreateMemberServiceTest.java
@@ -5,27 +5,24 @@ import com.example.demo.annotation.IntegrationTest;
 import com.example.demo.core.member.param.CreateMemberParam;
 import com.example.demo.core.member.result.FindMemberResult;
 import com.example.demo.infrastructure.persistence.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import static com.example.demo.MemberFixtures.EMAIL;
 import static com.example.demo.MemberFixtures.MEMBER_ID;
 import static com.example.demo.MemberFixtures.MEMBER_NAME;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@IntegrationTest
 @DisplayName("CreateMemberService")
+@IntegrationTest
+@RequiredArgsConstructor
 class CreateMemberServiceTest {
 
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private CreateMemberService createMemberService;
+    private final MemberRepository memberRepository;
+    private final CreateMemberService createMemberService;
 
     @AfterEach
     void tearDown() {
@@ -51,10 +48,10 @@ class CreateMemberServiceTest {
             void it() {
                 final FindMemberResult actual = createMemberService.create(param);
 
-                assertNotNull(actual);
-                assertEquals(MEMBER_ID, actual.getMemberId());
-                assertEquals(MEMBER_NAME, actual.getMemberName());
-                assertEquals(EMAIL, actual.getEmail());
+                assertThat(actual).isNotNull();
+                assertThat(actual.getMemberId()).isEqualTo(MEMBER_ID);
+                assertThat(actual.getMemberName()).isEqualTo(MEMBER_NAME);
+                assertThat(actual.getEmail()).isEqualTo(EMAIL);
             }
         }
     }

--- a/src/test/java/com/example/demo/core/member/service/FindMemberServiceTest.java
+++ b/src/test/java/com/example/demo/core/member/service/FindMemberServiceTest.java
@@ -4,29 +4,26 @@ import com.example.demo.annotation.IntegrationTest;
 import com.example.demo.core.member.domain.Member;
 import com.example.demo.core.member.result.FindMemberResult;
 import com.example.demo.infrastructure.persistence.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import static com.example.demo.MemberFixtures.EMAIL;
 import static com.example.demo.MemberFixtures.MEMBER_ID;
 import static com.example.demo.MemberFixtures.MEMBER_NAME;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@IntegrationTest
 @DisplayName("FindMemberServiceTest")
+@IntegrationTest
+@RequiredArgsConstructor
 class FindMemberServiceTest {
 
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private FindMemberService findMemberService;
+    private final MemberRepository memberRepository;
+    private final FindMemberService findMemberService;
 
     @AfterEach
     void tearDown() {
@@ -66,10 +63,10 @@ class FindMemberServiceTest {
             @Test
             @DisplayName("Member를 리턴한다.")
             void it() {
-                FindMemberResult result = findMemberService.findByMemberId(memberId);
+                FindMemberResult actual = findMemberService.findByMemberId(memberId);
 
-                assertInstanceOf(FindMemberResult.class, result);
-                assertNotNull(result);
+                assertThat(actual).isNotNull();
+                assertThat(actual).isExactlyInstanceOf(FindMemberResult.class);
             }
         }
     }

--- a/src/test/java/com/example/demo/core/order/service/CreateOrderServiceTest.java
+++ b/src/test/java/com/example/demo/core/order/service/CreateOrderServiceTest.java
@@ -15,9 +15,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.math.BigDecimal;
 
@@ -35,7 +35,7 @@ class CreateOrderServiceTest {
     @InjectMocks
     private CreateOrderService createOrderService;
 
-    @Mock
+    @MockitoBean
     private OrderNoGenerator orderNoGenerator;
 
     @AfterEach

--- a/src/test/java/com/example/demo/core/order/service/FindOrderServiceTest.java
+++ b/src/test/java/com/example/demo/core/order/service/FindOrderServiceTest.java
@@ -5,23 +5,22 @@ import com.example.demo.annotation.RepositoryTest;
 import com.example.demo.core.order.domain.OrderNo;
 import com.example.demo.core.order.result.OrderAggregateResult;
 import com.example.demo.infrastructure.persistence.order.OrderRepository;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@RepositoryTest
 @DisplayName("FindOrderService")
+@RepositoryTest
+@RequiredArgsConstructor
 class FindOrderServiceTest {
 
-    @Autowired
-    private OrderRepository orderRepository;
-
+    private final OrderRepository orderRepository;
     private FindOrderService sut;
 
     @BeforeEach

--- a/src/test/java/com/example/demo/core/product/service/CreateProductServiceTest.java
+++ b/src/test/java/com/example/demo/core/product/service/CreateProductServiceTest.java
@@ -1,27 +1,28 @@
 package com.example.demo.core.product.service;
 
 import com.example.demo.annotation.IntegrationTest;
-import com.example.demo.common.exceptions.BusinessErrorCode;
 import com.example.demo.common.exceptions.BusinessException;
 import com.example.demo.core.product.domain.Product;
-import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.product.param.CreateProductParam;
+import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.infrastructure.kafka.product.ProductKafkaPublisher;
 import com.example.demo.infrastructure.persistence.product.ProductRepository;
 import com.example.demo.infrastructure.persistence.stock.StockRepository;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 
 import static com.example.demo.ProductFixtures.PRODUCT_CODE;
 import static com.example.demo.ProductFixtures.PRODUCT_NAME;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static com.example.demo.common.exceptions.BusinessErrorCode.DUPLICATED_PRODUCT_CODE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@DisplayName("CreateProductService")
 @EmbeddedKafka(
     brokerProperties = {
         "listeners=PLAINTEXT://localhost:9092"
@@ -29,20 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
     ports = { 9092 }
 )
 @IntegrationTest
-@DisplayName("CreateProductService")
+@RequiredArgsConstructor
 class CreateProductServiceTest {
-
-    @Autowired
-    private CreateProductService createProductService;
-
-    @Autowired
-    private ProductRepository productRepository;
-
-    @Autowired
-    private StockRepository stockRepository;
-
-    @Autowired
-    private ProductKafkaPublisher productKafkaPublisher;
+    private final CreateProductService createProductService;
+    private final ProductRepository productRepository;
+    private final StockRepository stockRepository;
+    private final ProductKafkaPublisher productKafkaPublisher;
 
     @AfterEach
     void tearDown() {
@@ -83,11 +76,11 @@ class CreateProductServiceTest {
 
                 Product product = productRepository.findByProductCode(productCode)
                     .orElseThrow();
-                assertEquals(productName, product.getProductName());
+                assertThat(product.getProductName()).isEqualTo(productName);
 
                 Stock stock = stockRepository.findByProductCode(productCode)
                         .orElseThrow();
-                assertEquals(quantity, stock.getQuantity());
+                assertThat(stock.getQuantity()).isEqualTo(quantity);
             }
         }
 
@@ -103,11 +96,9 @@ class CreateProductServiceTest {
             @Test
             @DisplayName("BusinessException을 던진다.")
             void it() {
-                BusinessException exception = assertThrows(BusinessException.class, () -> {
-                    createProductService.create(param);
-                });
-
-                assertEquals(BusinessErrorCode.DUPLICATED_PRODUCT_CODE, exception.getBusinessErrorCode());
+                assertThatThrownBy(() -> createProductService.create(param))
+                    .isExactlyInstanceOf(BusinessException.class)
+                    .extracting("businessErrorCode").isEqualTo(DUPLICATED_PRODUCT_CODE);
             }
         }
     }

--- a/src/test/java/com/example/demo/core/product/service/FindProductSalesServiceTest.java
+++ b/src/test/java/com/example/demo/core/product/service/FindProductSalesServiceTest.java
@@ -9,30 +9,27 @@ import com.example.demo.core.product.result.FindProductSalesResult;
 import com.example.demo.infrastructure.persistence.product.ProductSalesRepository;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static io.github.resilience4j.circuitbreaker.CircuitBreaker.State.OPEN;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@IntegrationTest
 @DisplayName("FindProductSalesService")
+@IntegrationTest
+@RequiredArgsConstructor
 class FindProductSalesServiceTest extends TestDataInsertSupport {
 
-    @Autowired
-    private ProductSalesRepository productSalesRepository;
-
-    @Autowired
-    private FindProductSalesService findProductSalesService;
-
-    @Autowired
-    private CircuitBreakerRegistry circuitBreakerRegistry;
+    private final ProductSalesRepository productSalesRepository;
+    private final FindProductSalesService findProductSalesService;
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
 
     @AfterEach
     void tearDown() {
@@ -68,8 +65,8 @@ class FindProductSalesServiceTest extends TestDataInsertSupport {
 
                 final List<FindProductSalesResult> actual = findProductSalesService.top10(param);
 
-                assertEquals(10, actual.size());
-                assertEquals(11, actual.getFirst().salesQuantity());
+                assertThat(actual).hasSize(10);
+                assertThat(actual.getFirst().salesQuantity()).isEqualTo(11);
             }
         }
 
@@ -93,7 +90,7 @@ class FindProductSalesServiceTest extends TestDataInsertSupport {
                     findProductSalesService.top10(param);
                 }
 
-                assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.getState());
+                assertThat(circuitBreaker.getState()).isEqualTo(OPEN);
             }
         }
     }

--- a/src/test/java/com/example/demo/core/product/service/SearchProductServiceTest.java
+++ b/src/test/java/com/example/demo/core/product/service/SearchProductServiceTest.java
@@ -4,36 +4,31 @@ import com.example.demo.TestDataInsertSupport;
 import com.example.demo.annotation.IntegrationTest;
 import com.example.demo.common.enums.product.ProductStatus;
 import com.example.demo.core.product.domain.FoodProduct;
-import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.product.param.SearchProductParam;
 import com.example.demo.core.product.result.SearchProductResult;
+import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.infrastructure.persistence.product.ProductRepository;
 import com.example.demo.infrastructure.persistence.stock.StockRepository;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
 
 import static com.example.demo.ProductFixtures.PRODUCT_NAME;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@IntegrationTest
 @DisplayName("SearchProductService")
+@IntegrationTest
+@RequiredArgsConstructor
 class SearchProductServiceTest extends TestDataInsertSupport {
 
-    @Autowired
-    private SearchProductService searchProductService;
-
-    @Autowired
-    private StockRepository stockRepository;
-
-    @Autowired
-    private ProductRepository productRepository;
+    private final SearchProductService searchProductService;
+    private final StockRepository stockRepository;
+    private final ProductRepository productRepository;
 
     @AfterEach
     void tearDown() {
@@ -65,8 +60,8 @@ class SearchProductServiceTest extends TestDataInsertSupport {
             void it() {
                 final SearchProductResult actual = searchProductService.search(param);
 
-                assertInstanceOf(SearchProductResult.class, actual);
-                assertEquals(1, actual.getProducts().size());
+                assertThat(actual).isExactlyInstanceOf(SearchProductResult.class);
+                assertThat(actual.getProducts()).hasSize(1);
             }
         }
     }

--- a/src/test/java/com/example/demo/core/product/service/SellProductServiceTest.java
+++ b/src/test/java/com/example/demo/core/product/service/SellProductServiceTest.java
@@ -2,7 +2,6 @@ package com.example.demo.core.product.service;
 
 import com.example.demo.TestDataInsertSupport;
 import com.example.demo.annotation.IntegrationTest;
-import com.example.demo.common.exceptions.BusinessErrorCode;
 import com.example.demo.common.exceptions.BusinessException;
 import com.example.demo.core.product.domain.FoodProduct;
 import com.example.demo.core.product.domain.Product;
@@ -10,12 +9,12 @@ import com.example.demo.core.product.result.FindProductResult;
 import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.infrastructure.persistence.product.ProductRepository;
 import com.example.demo.infrastructure.persistence.stock.StockRepository;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
 
@@ -23,22 +22,20 @@ import static com.example.demo.ProductFixtures.PRODUCT_CODE;
 import static com.example.demo.ProductFixtures.PRODUCT_NAME;
 import static com.example.demo.common.enums.product.ProductStatus.SELLING;
 import static com.example.demo.common.enums.product.ProductStatus.SOLD_OUT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static com.example.demo.common.exceptions.BusinessErrorCode.NOT_FOUND_PRODUCT;
+import static com.example.demo.common.exceptions.BusinessErrorCode.NOT_POSSIBLE_CHANGE_SELLING_AS_STOCK_QUANTITY_EMPTY;
+import static com.example.demo.common.exceptions.BusinessErrorCode.NOT_POSSIBLE_CHANGE_SELLING_AS_STOCK_QUANTITY_LESS_THAN_MIN_LIMIT_STOCK_QUANTITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@IntegrationTest
 @DisplayName("SellProductService")
+@IntegrationTest
+@RequiredArgsConstructor
 class SellProductServiceTest extends TestDataInsertSupport {
 
-    @Autowired
-    ProductRepository productRepository;
-
-    @Autowired
-    StockRepository stockRepository;
-
-    @Autowired
-    SellProductService sellProductService;
+    private final ProductRepository productRepository;
+    private final StockRepository stockRepository;
+    private final SellProductService sellProductService;
 
     @AfterEach
     void tearDown() {
@@ -57,11 +54,9 @@ class SellProductServiceTest extends TestDataInsertSupport {
             @Test
             @DisplayName("BusinessException을 던진다.")
             void it() {
-                BusinessException exception = assertThrows(BusinessException.class, () ->
-                    sellProductService.sell(PRODUCT_CODE)
-                );
-
-                assertEquals(BusinessErrorCode.NOT_FOUND_PRODUCT, exception.getBusinessErrorCode());
+                assertThatThrownBy(() -> sellProductService.sell(PRODUCT_CODE))
+                    .isExactlyInstanceOf(BusinessException.class)
+                    .extracting("businessErrorCode").isEqualTo(NOT_FOUND_PRODUCT);
             }
         }
 
@@ -85,14 +80,10 @@ class SellProductServiceTest extends TestDataInsertSupport {
                 @Test
                 @DisplayName("BusinessException을 던진다")
                 void it () {
-                    BusinessException exception = assertThrows(BusinessException.class, () ->
-                        sellProductService.sell(productCode)
-                    );
-
-                    assertEquals(
-                        BusinessErrorCode.NOT_POSSIBLE_CHANGE_SELLING_AS_STOCK_QUANTITY_EMPTY,
-                        exception.getBusinessErrorCode()
-                    );
+                    assertThatThrownBy(() -> sellProductService.sell(productCode))
+                        .isExactlyInstanceOf(BusinessException.class)
+                        .extracting("businessErrorCode")
+                        .isEqualTo(NOT_POSSIBLE_CHANGE_SELLING_AS_STOCK_QUANTITY_EMPTY);
                 }
             }
 
@@ -112,14 +103,10 @@ class SellProductServiceTest extends TestDataInsertSupport {
                 @Test
                 @DisplayName("BusinessException을 던진다.")
                 void it() {
-                    BusinessException exception = assertThrows(BusinessException.class, () ->
-                        sellProductService.sell(productCode)
-                    );
-
-                    assertEquals(
-                        BusinessErrorCode.NOT_POSSIBLE_CHANGE_SELLING_AS_STOCK_QUANTITY_LESS_THAN_MIN_LIMIT_STOCK_QUANTITY,
-                        exception.getBusinessErrorCode()
-                    );
+                    assertThatThrownBy(() -> sellProductService.sell(productCode))
+                        .isExactlyInstanceOf(BusinessException.class)
+                        .extracting("businessErrorCode")
+                        .isEqualTo(NOT_POSSIBLE_CHANGE_SELLING_AS_STOCK_QUANTITY_LESS_THAN_MIN_LIMIT_STOCK_QUANTITY);
                 }
             }
 
@@ -143,8 +130,8 @@ class SellProductServiceTest extends TestDataInsertSupport {
 
                     Product product = productRepository.findByProductCode(productCode).get();
 
-                    assertInstanceOf(FindProductResult.class, result);
-                    assertEquals(SELLING, product.getProductStatus());
+                    assertThat(result).isExactlyInstanceOf(FindProductResult.class);
+                    assertThat(product.getProductStatus()).isEqualTo(SELLING);
                 }
             }
         }

--- a/src/test/java/com/example/demo/core/product/service/SoldOutProductServiceTest.java
+++ b/src/test/java/com/example/demo/core/product/service/SoldOutProductServiceTest.java
@@ -3,38 +3,36 @@ package com.example.demo.core.product.service;
 import com.example.demo.TestDataInsertSupport;
 import com.example.demo.annotation.IntegrationTest;
 import com.example.demo.common.enums.product.ProductStatus;
-import com.example.demo.common.exceptions.BusinessErrorCode;
 import com.example.demo.common.exceptions.BusinessException;
 import com.example.demo.core.product.domain.FoodProduct;
 import com.example.demo.core.product.domain.Product;
 import com.example.demo.core.product.result.FindProductResult;
 import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.infrastructure.persistence.product.ProductRepository;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
 
 import static com.example.demo.ProductFixtures.PRODUCT_CODE;
 import static com.example.demo.ProductFixtures.PRODUCT_NAME;
 import static com.example.demo.common.enums.product.ProductStatus.SOLD_OUT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static com.example.demo.common.exceptions.BusinessErrorCode.NOT_FOUND_PRODUCT;
+import static com.example.demo.common.exceptions.BusinessErrorCode.NOT_POSSIBLE_CHANGE_END_TO_SOLD_OUT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@IntegrationTest
 @DisplayName("CreateProductService")
+@IntegrationTest
+@RequiredArgsConstructor
 class SoldOutProductServiceTest extends TestDataInsertSupport {
 
-    @Autowired
-    SoldOutProductService soldOutProductService;
-
-    @Autowired
-    ProductRepository productRepository;
+    private final SoldOutProductService soldOutProductService;
+    private final ProductRepository productRepository;
 
     @AfterEach
     void tearDown() {
@@ -52,11 +50,9 @@ class SoldOutProductServiceTest extends TestDataInsertSupport {
             @Test
             @DisplayName("BusinessException을 던진다.")
             void it() {
-                BusinessException exception = assertThrows(BusinessException.class, () ->
-                    soldOutProductService.soldOut(PRODUCT_CODE)
-                );
-
-                assertEquals(BusinessErrorCode.NOT_FOUND_PRODUCT, exception.getBusinessErrorCode());
+                assertThatThrownBy(() -> soldOutProductService.soldOut(PRODUCT_CODE))
+                    .isExactlyInstanceOf(BusinessException.class)
+                    .extracting("businessErrorCode").isEqualTo(NOT_FOUND_PRODUCT);
             }
         }
 
@@ -84,8 +80,8 @@ class SoldOutProductServiceTest extends TestDataInsertSupport {
 
                     Product product = productRepository.findByProductCode(productCode).get();
 
-                    assertInstanceOf(FindProductResult.class, result);
-                    assertEquals(SOLD_OUT, product.getProductStatus());
+                    assertThat(result).isExactlyInstanceOf(FindProductResult.class);
+                    assertThat(product.getProductStatus()).isEqualTo(SOLD_OUT);
                 }
             }
 
@@ -105,11 +101,10 @@ class SoldOutProductServiceTest extends TestDataInsertSupport {
                 @Test
                 @DisplayName("BusinessException을 던진다.")
                 void it() {
-                    BusinessException exception = assertThrows(BusinessException.class, () ->
-                        soldOutProductService.soldOut(productCode)
-                    );
-
-                    assertEquals(BusinessErrorCode.NOT_POSSIBLE_CHANGE_END_TO_SOLD_OUT, exception.getBusinessErrorCode());
+                    assertThatThrownBy(() -> soldOutProductService.soldOut(productCode))
+                        .isExactlyInstanceOf(BusinessException.class)
+                        .extracting("businessErrorCode")
+                        .isEqualTo(NOT_POSSIBLE_CHANGE_END_TO_SOLD_OUT);
                 }
             }
         }

--- a/src/test/java/com/example/demo/core/stock/service/DecreaseStockServiceTest.java
+++ b/src/test/java/com/example/demo/core/stock/service/DecreaseStockServiceTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -41,7 +41,7 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
     @Autowired
     StockRepository stockRepository;
 
-    @MockBean
+    @MockitoBean
     SoldOutProductService soldOutProductService;
 
     @Autowired

--- a/src/test/java/com/example/demo/core/stock/service/IncreaseStockServiceWithDecreaseTest.java
+++ b/src/test/java/com/example/demo/core/stock/service/IncreaseStockServiceWithDecreaseTest.java
@@ -6,8 +6,6 @@ import com.example.demo.core.stock.domain.QStock;
 import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.stock.param.DecreaseStockParam;
 import com.example.demo.core.stock.param.IncreaseStockParam;
-import com.example.demo.core.stock.service.DecreaseStockService;
-import com.example.demo.core.stock.service.IncreaseStockService;
 import com.example.demo.infrastructure.persistence.product.ProductRepository;
 import com.example.demo.infrastructure.persistence.stock.StockRepository;
 import org.junit.jupiter.api.AfterEach;


### PR DESCRIPTION
의존성 최신화

트러블슈팅
1. `io.github.resilience4j:resilience4j-spring-boot3:2.3.0` 최신화 실패
2.3.0 버전 사용 시 `RxJava3FallbackDecorator ClassNotFoundException` 발생
관련 내용: https://github.com/resilience4j/resilience4j/issues/2265
본 프로젝트는 spring-cloud를 사용하고 있어서 `spring-cloud-starter-circuitbreaker-resilience4j`로 대체

2. `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)` 테스트 실패
이전 버전에서는 `@RecordApplicationEvents` + `ApplicationEventPublisher` 조합으로 이벤트 발행 시 `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`이 수신했었음
버전 최신화되면서 기존 방법으로 이벤트를 수신하지 못 함
테스트용 엔티티를 flush()하여 이벤트가 트리거 될 수 있도록 함

