### PR TITLE
Feature/decrease stock code refactoring

### DIFF
--- a/src/main/java/com/example/demo/common/exceptions/BusinessException.java
+++ b/src/main/java/com/example/demo/common/exceptions/BusinessException.java
@@ -1,7 +1,14 @@
 package com.example.demo.common.exceptions;
 
+import lombok.Getter;
+
+import java.io.Serial;
+
+@Getter
 public class BusinessException extends RuntimeException {
 
+    @Serial
+    private static final long serialVersionUID = -7796732682612229338L;
     private final BusinessErrorCode businessErrorCode;
 
     public BusinessException(BusinessErrorCode businessErrorCode) {
@@ -11,9 +18,5 @@ public class BusinessException extends RuntimeException {
     public BusinessException(String message, BusinessErrorCode businessErrorCode) {
         super(message);
         this.businessErrorCode = businessErrorCode;
-    }
-
-    public BusinessErrorCode getBusinessErrorCode() {
-        return businessErrorCode;
     }
 }

--- a/src/main/java/com/example/demo/core/stock/domain/InvalidStockQuantityException.java
+++ b/src/main/java/com/example/demo/core/stock/domain/InvalidStockQuantityException.java
@@ -1,0 +1,17 @@
+package com.example.demo.core.stock.domain;
+
+import com.example.demo.common.exceptions.BusinessException;
+
+import java.io.Serial;
+
+import static com.example.demo.common.exceptions.BusinessErrorCode.INVALID_STOCK_QUANTITY;
+
+public class InvalidStockQuantityException extends BusinessException {
+
+    @Serial
+    private static final long serialVersionUID = -8163366324230620494L;
+
+    public InvalidStockQuantityException() {
+        super(INVALID_STOCK_QUANTITY);
+    }
+}

--- a/src/main/java/com/example/demo/core/stock/domain/Stock.java
+++ b/src/main/java/com/example/demo/core/stock/domain/Stock.java
@@ -1,7 +1,5 @@
 package com.example.demo.core.stock.domain;
 
-import com.example.demo.common.exceptions.BusinessErrorCode;
-import com.example.demo.common.exceptions.BusinessException;
 import com.example.demo.config.persistence.AuditEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,11 +40,11 @@ public class Stock extends AuditEntity {
         long decreasedQuantity = this.quantity - quantity;
 
         if (decreasedQuantity < this.minLimitQuantity) {
-            throw new BusinessException(BusinessErrorCode.INVALID_STOCK_QUANTITY);
+            throw new InvalidStockQuantityException();
         }
 
         if (decreasedQuantity < 0) {
-            throw new BusinessException(BusinessErrorCode.INVALID_STOCK_QUANTITY);
+            throw new InvalidStockQuantityException();
         }
 
         this.quantity = decreasedQuantity;

--- a/src/main/java/com/example/demo/core/stock/param/DecreaseStockParam.java
+++ b/src/main/java/com/example/demo/core/stock/param/DecreaseStockParam.java
@@ -1,27 +1,24 @@
 package com.example.demo.core.stock.param;
 
-import lombok.Getter;
-
+import java.util.Objects;
 import java.util.Set;
 
-@Getter
-public class DecreaseStockParam {
+public record DecreaseStockParam(Set<Stock> stocks) {
 
-    private final Set<Stock> stocks;
+    public record Stock(
+        String productCode,
+        long quantity
+    ) {
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            Stock stock = (Stock) o;
+            return Objects.equals(productCode, stock.productCode);
+        }
 
-    public DecreaseStockParam(Set<Stock> stocks) {
-        this.stocks = stocks;
-    }
-
-    @Getter
-    public static class Stock {
-
-        private final String productCode;
-        private final long quantity;
-
-        public Stock(String productCode, long quantity) {
-            this.productCode = productCode;
-            this.quantity = quantity;
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(productCode);
         }
     }
 }

--- a/src/main/java/com/example/demo/core/stock/service/DecreaseStockService.java
+++ b/src/main/java/com/example/demo/core/stock/service/DecreaseStockService.java
@@ -23,19 +23,19 @@ public class DecreaseStockService {
     private final SoldOutProductService soldOutProductService;
 
     public void decrease(final DecreaseStockParam param) {
-        param.getStocks()
+        param.stocks()
             .stream()
-            .sorted(Comparator.comparing(DecreaseStockParam.Stock::getProductCode))
+            .sorted(Comparator.comparing(DecreaseStockParam.Stock::productCode))
             .collect(Collectors.toCollection(LinkedHashSet::new))
             .forEach(item -> {
-                    Stock decreasedStock = stockRepository.findByProductCodeForUpdate(item.getProductCode())
+                    Stock decreasedStock = stockRepository.findByProductCodeForUpdate(item.productCode())
                         .orElseThrow()
-                        .decrease(item.getQuantity());
+                        .decrease(item.quantity());
 
                     log.info("[Decrease Stock] stockId: {} quantity: {}", decreasedStock.getStockId(), decreasedStock.getQuantity());
 
                     if (decreasedStock.isLimitQuantity()) {
-                        soldOutProductService.soldOut(item.getProductCode());
+                        soldOutProductService.soldOut(item.productCode());
                     }
                 }
             );

--- a/src/main/java/com/example/demo/core/stock/service/DecreaseStockService.java
+++ b/src/main/java/com/example/demo/core/stock/service/DecreaseStockService.java
@@ -1,9 +1,11 @@
 package com.example.demo.core.stock.service;
 
-import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.product.service.SoldOutProductService;
+import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.stock.param.DecreaseStockParam;
 import com.example.demo.infrastructure.persistence.stock.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,20 +13,16 @@ import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
 
-@Transactional
+@Slf4j
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class DecreaseStockService {
 
     private final StockRepository stockRepository;
-
     private final SoldOutProductService soldOutProductService;
 
-    public DecreaseStockService(StockRepository stockRepository, SoldOutProductService soldOutProductService) {
-        this.stockRepository = stockRepository;
-        this.soldOutProductService = soldOutProductService;
-    }
-
-    public void decrease(DecreaseStockParam param) {
+    public void decrease(final DecreaseStockParam param) {
         param.getStocks()
             .stream()
             .sorted(Comparator.comparing(DecreaseStockParam.Stock::getProductCode))
@@ -33,6 +31,8 @@ public class DecreaseStockService {
                     Stock decreasedStock = stockRepository.findByProductCodeForUpdate(item.getProductCode())
                         .orElseThrow()
                         .decrease(item.getQuantity());
+
+                    log.info("[Decrease Stock] stockId: {} quantity: {}", decreasedStock.getStockId(), decreasedStock.getQuantity());
 
                     if (decreasedStock.isLimitQuantity()) {
                         soldOutProductService.soldOut(item.getProductCode());

--- a/src/main/java/com/example/demo/web/v1/stock/DecreaseStockController.java
+++ b/src/main/java/com/example/demo/web/v1/stock/DecreaseStockController.java
@@ -4,18 +4,16 @@ import com.example.demo.core.stock.service.DecreaseStockService;
 import com.example.demo.web.ApiResponse;
 import com.example.demo.web.v1.stock.request.DecreaseStockRequest;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class DecreaseStockController {
 
     private final DecreaseStockService decreaseStockService;
-
-    public DecreaseStockController(DecreaseStockService decreaseStockService) {
-        this.decreaseStockService = decreaseStockService;
-    }
 
     @PostMapping("/v1/stocks/decrease")
     public ApiResponse<Void> decrease(@RequestBody @Valid DecreaseStockRequest request) {

--- a/src/main/java/com/example/demo/web/v1/stock/request/DecreaseStockRequest.java
+++ b/src/main/java/com/example/demo/web/v1/stock/request/DecreaseStockRequest.java
@@ -1,32 +1,21 @@
 package com.example.demo.web.v1.stock.request;
 
 import com.example.demo.core.stock.param.DecreaseStockParam;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class DecreaseStockRequest {
+public record DecreaseStockRequest(@Valid @Size(min = 1) Set<Stock> stocks) {
 
-    @NotEmpty
-    private Set<Stock> stocks;
-
-    @Getter
-    public static class Stock {
-
-        private final String productCode;
-        private final long quantity;
-
-        public Stock(String productCode, long quantity) {
-            this.productCode = productCode;
-            this.quantity = quantity;
-        }
-
+    public record Stock(
+        @NotNull @NotEmpty String productCode,
+        @Positive long quantity
+    ) {
         public DecreaseStockParam.Stock toParam() {
             return new DecreaseStockParam.Stock(productCode, quantity);
         }

--- a/src/test/java/com/example/demo/core/stock/param/DecreaseStockParamTest.java
+++ b/src/test/java/com/example/demo/core/stock/param/DecreaseStockParamTest.java
@@ -1,0 +1,99 @@
+package com.example.demo.core.stock.param;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DecreaseStockParam")
+class DecreaseStockParamTest {
+
+    @Nested
+    @DisplayName("동일한 productCode를 가진 Stock 객체는")
+    class SameProductCodeTest {
+
+        private final DecreaseStockParam.Stock stock1 = new DecreaseStockParam.Stock("P001", 3L);
+        private final DecreaseStockParam.Stock stock2 = new DecreaseStockParam.Stock("P001", 5L);
+
+        @Test
+        @DisplayName("동등성 비교 시 true를 반환한다")
+        void equals_returnsTrue() {
+            assertThat(stock1).isEqualTo(stock2);
+        }
+
+        @Test
+        @DisplayName("동일한 해시코드를 가진다")
+        void hashCode_areSame() {
+            assertThat(stock1.hashCode()).isEqualTo(stock2.hashCode());
+        }
+
+        @Test
+        @DisplayName("Set에 추가할 때 중복으로 간주되어 하나만 저장된다")
+        void set_containsOnlyOneElement() {
+            // when
+            Set<DecreaseStockParam.Stock> stockSet = new HashSet<>(List.of(stock1, stock2));
+
+            // then
+            assertThat(stockSet).hasSize(1);
+            assertThat(stockSet).containsExactlyInAnyOrder(stock1);
+        }
+    }
+
+    @Nested
+    @DisplayName("다른 productCode를 가진 Stock 객체는")
+    class DifferentProductCodeTest {
+
+        private final DecreaseStockParam.Stock stock1 = new DecreaseStockParam.Stock("P001", 3L);
+        private final DecreaseStockParam.Stock stock2 = new DecreaseStockParam.Stock("P002", 3L);
+
+        @Test
+        @DisplayName("동등성 비교 시 false를 반환한다")
+        void equals_returnsFalse() {
+            assertThat(stock1).isNotEqualTo(stock2);
+        }
+
+        @Test
+        @DisplayName("다른 해시코드를 가질 수 있다 (해시 충돌 가능성은 있지만, 다른 객체임을 보장)")
+        void hashCode_areDifferent() {
+            assertThat(stock1.hashCode()).isNotEqualTo(stock2.hashCode());
+        }
+
+        @Test
+        @DisplayName("Set에 추가할 때 모두 저장된다")
+        void set_containsBothElements() {
+            // when
+            Set<DecreaseStockParam.Stock> stockSet = Set.of(stock1, stock2);
+
+            // then
+            assertThat(stockSet).hasSize(2);
+            assertThat(stockSet).containsExactlyInAnyOrder(stock1, stock2);
+        }
+    }
+
+    @Nested
+    @DisplayName("DecreaseStockParam 생성 시")
+    class DecreaseStockParamConstructorTest {
+
+        @Test
+        @DisplayName("동일한 productCode를 가진 Stock은 중복 제거되어 저장된다")
+        void removesDuplicateProductCode() {
+            // given
+            var stock1 = new DecreaseStockParam.Stock("P001", 3L);
+            var stock2 = new DecreaseStockParam.Stock("P001", 5L);
+            var stock3 = new DecreaseStockParam.Stock("P002", 1L);
+
+            // when
+            var param = new DecreaseStockParam(new HashSet<>(List.of(stock1, stock2, stock3)));
+
+            // then
+            assertThat(param.stocks()).hasSize(2);
+            assertThat(param.stocks()).containsExactlyInAnyOrder(stock1, stock3);
+            // 마지막에 추가된 동일 productCode의 Stock이 유지됨 (Set의 특성상 순서는 보장되지 않음)
+        }
+    }
+}

--- a/src/test/java/com/example/demo/core/stock/service/DecreaseStockServiceTest.java
+++ b/src/test/java/com/example/demo/core/stock/service/DecreaseStockServiceTest.java
@@ -3,9 +3,9 @@ package com.example.demo.core.stock.service;
 import com.example.demo.TestDataInsertSupport;
 import com.example.demo.TestFixtures;
 import com.example.demo.annotation.IntegrationTest;
-import com.example.demo.common.exceptions.BusinessException;
 import com.example.demo.core.product.result.FindProductResult;
 import com.example.demo.core.product.service.SoldOutProductService;
+import com.example.demo.core.stock.domain.InvalidStockQuantityException;
 import com.example.demo.core.stock.domain.QStock;
 import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.stock.param.DecreaseStockParam;
@@ -120,10 +120,10 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                 }
 
                 @Test
-                @DisplayName("BusinessException을 던지고, 차감한 재고를 롤백한다.")
+                @DisplayName("InvalidStockQuantityException을 던지고, 차감한 재고를 롤백한다.")
                 void it() {
                     assertThatThrownBy(() -> decreaseStockService.decrease(param))
-                        .isExactlyInstanceOf(BusinessException.class)
+                        .isExactlyInstanceOf(InvalidStockQuantityException.class)
                         .extracting("businessErrorCode")
                         .isEqualTo(INVALID_STOCK_QUANTITY);
 
@@ -162,7 +162,7 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                 @DisplayName("BusinessException을 던지고, 차감한 재고를 롤백한다.")
                 void it() {
                     assertThatThrownBy(() -> decreaseStockService.decrease(param))
-                        .isExactlyInstanceOf(BusinessException.class)
+                        .isExactlyInstanceOf(InvalidStockQuantityException.class)
                         .extracting("businessErrorCode")
                         .isEqualTo(INVALID_STOCK_QUANTITY);
 

--- a/src/test/java/com/example/demo/core/stock/service/DecreaseStockServiceTest.java
+++ b/src/test/java/com/example/demo/core/stock/service/DecreaseStockServiceTest.java
@@ -1,9 +1,8 @@
 package com.example.demo.core.stock.service;
 
 import com.example.demo.TestDataInsertSupport;
+import com.example.demo.TestFixtures;
 import com.example.demo.annotation.IntegrationTest;
-import com.example.demo.common.enums.product.ProductStatus;
-import com.example.demo.common.exceptions.BusinessErrorCode;
 import com.example.demo.common.exceptions.BusinessException;
 import com.example.demo.core.product.result.FindProductResult;
 import com.example.demo.core.product.service.SoldOutProductService;
@@ -11,41 +10,38 @@ import com.example.demo.core.stock.domain.QStock;
 import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.stock.param.DecreaseStockParam;
 import com.example.demo.infrastructure.persistence.stock.StockRepository;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.example.demo.ProductFixtures.PRODUCT_NAME;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.times;
+import static com.example.demo.common.exceptions.BusinessErrorCode.INVALID_STOCK_QUANTITY;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @IntegrationTest
+@RequiredArgsConstructor
 @DisplayName("DecreaseStockService")
 class DecreaseStockServiceTest extends TestDataInsertSupport {
 
-    @Autowired
-    StockRepository stockRepository;
+    private final StockRepository stockRepository;
+    private final DecreaseStockService decreaseStockService;
 
     @MockitoBean
     SoldOutProductService soldOutProductService;
-
-    @Autowired
-    DecreaseStockService decreaseStockService;
 
     @AfterEach
     void tearDown() {
@@ -80,14 +76,8 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                     saveAll(stocks);
 
                     when(soldOutProductService.soldOut("A202307300130")).thenReturn(
-                        new FindProductResult(
-                            "A202307300130",
-                            PRODUCT_NAME,
-                            ProductStatus.SOLD_OUT,
-                            100,
-                            LocalDateTime.now(),
-                            LocalDateTime.now()
-                        )
+                        TestFixtures.get().giveMeBuilder(FindProductResult.class)
+                            .sample()
                     );
                 }
 
@@ -96,16 +86,17 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                 void it() {
                     decreaseStockService.decrease(param);
 
-                    List<Stock> results = jpaQueryFactory.selectFrom(QStock.stock)
+                    List<Stock> actual = jpaQueryFactory.selectFrom(QStock.stock)
                         .where(QStock.stock.productCode.in(List.of("A202307300130", "A202307300131")))
                         .fetch();
 
-                    assertAll(
-                        () -> assertEquals(0, results.get(0).getQuantity()),
-                        () -> assertEquals(5, results.get(1).getQuantity()),
-                        () -> verify(soldOutProductService, times(1)).soldOut("A202307300130"),
-                        () -> verify(soldOutProductService, times(0)).soldOut("A202307300131")
-                    );
+                    assertSoftly(it -> {
+                        it.assertThat(actual.getFirst().getQuantity()).isEqualTo(0);
+                        it.assertThat(actual.get(1).getQuantity()).isEqualTo(5);
+                    });
+
+                    verify(soldOutProductService).soldOut("A202307300130");
+                    verify(soldOutProductService, never()).soldOut("A202307300131");
                 }
             }
 
@@ -131,19 +122,19 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                 @Test
                 @DisplayName("BusinessException을 던지고, 차감한 재고를 롤백한다.")
                 void it() {
-                    BusinessException exception = assertThrows(BusinessException.class, () -> {
-                        decreaseStockService.decrease(param);
-                    });
+                    assertThatThrownBy(() -> decreaseStockService.decrease(param))
+                        .isExactlyInstanceOf(BusinessException.class)
+                        .extracting("businessErrorCode")
+                        .isEqualTo(INVALID_STOCK_QUANTITY);
 
-                    List<Stock> results = jpaQueryFactory.selectFrom(QStock.stock)
+                    List<Stock> actual = jpaQueryFactory.selectFrom(QStock.stock)
                         .where(QStock.stock.productCode.in(List.of("A202307300132", "A202307300133")))
                         .fetch();
 
-                    assertAll(
-                        () -> assertEquals(BusinessErrorCode.INVALID_STOCK_QUANTITY, exception.getBusinessErrorCode()),
-                        () -> assertEquals(10, results.get(0).getQuantity()),
-                        () -> assertEquals(0, results.get(1).getQuantity())
-                    );
+                    assertSoftly(it -> {
+                        it.assertThat(actual.getFirst().getQuantity()).isEqualTo(10);
+                        it.assertThat(actual.get(1).getQuantity()).isEqualTo(0);
+                    });
                 }
             }
 
@@ -170,28 +161,29 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                 @Test
                 @DisplayName("BusinessException을 던지고, 차감한 재고를 롤백한다.")
                 void it() {
-                    BusinessException exception = assertThrows(BusinessException.class, () -> {
-                        decreaseStockService.decrease(param);
-                    });
+                    assertThatThrownBy(() -> decreaseStockService.decrease(param))
+                        .isExactlyInstanceOf(BusinessException.class)
+                        .extracting("businessErrorCode")
+                        .isEqualTo(INVALID_STOCK_QUANTITY);
 
-                    List<Stock> results = jpaQueryFactory.selectFrom(QStock.stock)
+                    List<Stock> actual = jpaQueryFactory.selectFrom(QStock.stock)
                         .where(QStock.stock.productCode.in(List.of("A202307300140", "A202307300141")))
                         .fetch();
 
-                    assertAll(
-                        () -> assertEquals(BusinessErrorCode.INVALID_STOCK_QUANTITY, exception.getBusinessErrorCode()),
-                        () -> assertEquals(10, results.get(0).getQuantity()),
-                        () -> assertEquals(10, results.get(1).getQuantity())
-                    );
+                    assertSoftly(it -> {
+                        it.assertThat(actual.getFirst().getQuantity()).isEqualTo(10);
+                        it.assertThat(actual.get(1).getQuantity()).isEqualTo(10);
+                    });
                 }
             }
         }
 
         @Nested
-        @DisplayName("동시에 10번의 재고를 차감했을 때")
+        @DisplayName("동시에 총 10번의 재고를 차감했을 때")
         class Context_tenTimesAsTheSameTime {
 
-            int threadCount = 10;
+            int threadCount = 5; // 스레드 개수
+            int executeCount = 10; // 수행 회수
 
             @Nested
             @DisplayName("재고가 충분할 경우")
@@ -216,30 +208,41 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                 @Test
                 @DisplayName("정상적으로 50개씩 재고를 차감한다.")
                 void it() throws InterruptedException {
-                    ExecutorService executorService = Executors.newFixedThreadPool(5);
-                    CountDownLatch latch = new CountDownLatch(threadCount);
+                    ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+                    CountDownLatch startLatch = new CountDownLatch(1);
+                    CountDownLatch endLatch = new CountDownLatch(executeCount);
+                    AtomicInteger successCount = new AtomicInteger();
+                    AtomicInteger failureCount = new AtomicInteger();
 
-                    for (int i = 0; i < threadCount; i++) {
+                    for (int i = 0; i < executeCount; i++) {
                         executorService.submit(() -> {
                                 try {
+                                    startLatch.await();
                                     decreaseStockService.decrease(param);
+                                    successCount.incrementAndGet();
+                                } catch (Exception e) {
+                                    failureCount.incrementAndGet();
                                 } finally {
-                                    latch.countDown();
+                                    endLatch.countDown();
                                 }
                             }
                         );
                     }
 
-                    latch.await();
+                    startLatch.countDown();
+                    endLatch.await();
+                    executorService.shutdown();
 
-                    List<Stock> results = jpaQueryFactory.selectFrom(QStock.stock)
+                    List<Stock> actual = jpaQueryFactory.selectFrom(QStock.stock)
                         .where(QStock.stock.productCode.in(List.of("A202307300134", "A202307300135")))
                         .fetch();
 
-                    assertAll(
-                        () -> assertEquals(50, results.get(0).getQuantity()),
-                        () -> assertEquals(50, results.get(1).getQuantity())
-                    );
+                    assertSoftly(it -> {
+                        it.assertThat(successCount.get()).isEqualTo(10);
+                        it.assertThat(failureCount.get()).isEqualTo(0);
+                        it.assertThat(actual.getFirst().getQuantity()).isEqualTo(50);
+                        it.assertThat(actual.get(1).getQuantity()).isEqualTo(50);
+                    });
                 }
             }
 
@@ -265,29 +268,41 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                 @Test
                 @DisplayName("BusinessException을 던지고, 마지막 차감 실패한 재고를 롤백하여 4개가 남는다.")
                 void it() throws InterruptedException {
-                    ExecutorService executorService = Executors.newFixedThreadPool(5);
-                    CountDownLatch latch = new CountDownLatch(threadCount);
+                    ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+                    CountDownLatch startLatch = new CountDownLatch(1);
+                    CountDownLatch endLatch = new CountDownLatch(executeCount);
+                    AtomicInteger successCount = new AtomicInteger();
+                    AtomicInteger failureCount = new AtomicInteger();
 
-                    for (int i = 0; i < threadCount; i++) {
+                    for (int i = 0; i < executeCount; i++) {
                         executorService.submit(() -> {
                                 try {
+                                    startLatch.await();
                                     decreaseStockService.decrease(param);
+                                    successCount.incrementAndGet();
+                                } catch (Exception e) {
+                                    failureCount.incrementAndGet();
                                 } finally {
-                                    latch.countDown();
+                                    endLatch.countDown();
                                 }
                             }
                         );
                     }
-                    latch.await();
 
-                    List<Stock> results = jpaQueryFactory.selectFrom(QStock.stock)
+                    startLatch.countDown();
+                    endLatch.await();
+                    executorService.shutdown();
+
+                    List<Stock> actual = jpaQueryFactory.selectFrom(QStock.stock)
                         .where(QStock.stock.productCode.in(List.of("A202307300136", "A202307300137")))
                         .fetch();
 
-                    assertAll(
-                        () -> assertEquals(4, results.get(0).getQuantity()),
-                        () -> assertEquals(4, results.get(1).getQuantity())
-                    );
+                    assertSoftly(it -> {
+                        it.assertThat(successCount.get()).isEqualTo(9);
+                        it.assertThat(failureCount.get()).isEqualTo(1);
+                        it.assertThat(actual.getFirst().getQuantity()).isEqualTo(4);
+                        it.assertThat(actual.get(1).getQuantity()).isEqualTo(4);
+                    });
                 }
             }
 
@@ -311,46 +326,52 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                     saveAll(stocks);
 
                     when(soldOutProductService.soldOut("A202307300138")).thenReturn(
-                        new FindProductResult(
-                            "A202307300138",
-                            PRODUCT_NAME,
-                            ProductStatus.SOLD_OUT,
-                            100,
-                            LocalDateTime.now(),
-                            LocalDateTime.now()
-                        )
+                        TestFixtures.get().giveMeBuilder(FindProductResult.class)
+                            .sample()
                     );
                 }
 
                 @Test
                 @DisplayName("정상적으로 50개씩 재고를 차감하고, 재고가 모두 소진된 상품은 SoldOut()을 호출한다.")
                 void it() throws InterruptedException {
-                    ExecutorService executorService = Executors.newFixedThreadPool(5);
-                    CountDownLatch latch = new CountDownLatch(threadCount);
+                    ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+                    CountDownLatch startLatch = new CountDownLatch(1);
+                    CountDownLatch endLatch = new CountDownLatch(executeCount);
+                    AtomicInteger successCount = new AtomicInteger();
+                    AtomicInteger failureCount = new AtomicInteger();
 
-                    for (int i = 0; i < threadCount; i++) {
+                    for (int i = 0; i < executeCount; i++) {
                         executorService.submit(() -> {
                                 try {
+                                    startLatch.await();
                                     decreaseStockService.decrease(param);
+                                    successCount.incrementAndGet();
+                                } catch (Exception e) {
+                                    failureCount.incrementAndGet();
                                 } finally {
-                                    latch.countDown();
+                                    endLatch.countDown();
                                 }
                             }
                         );
                     }
 
-                    latch.await();
+                    startLatch.countDown();
+                    endLatch.await();
+                    executorService.shutdown();
 
-                    List<Stock> results = jpaQueryFactory.selectFrom(QStock.stock)
+                    List<Stock> actual = jpaQueryFactory.selectFrom(QStock.stock)
                         .where(QStock.stock.productCode.in(List.of("A202307300138", "A202307300139")))
                         .fetch();
 
-                    assertAll(
-                        () -> assertEquals(0, results.get(0).getQuantity()),
-                        () -> assertEquals(1, results.get(1).getQuantity()),
-                        () -> verify(soldOutProductService, times(1)).soldOut("A202307300138"),
-                        () -> verify(soldOutProductService, times(0)).soldOut("A202307300139")
-                    );
+                    assertSoftly(it -> {
+                        it.assertThat(successCount.get()).isEqualTo(10);
+                        it.assertThat(failureCount.get()).isEqualTo(0);
+                        it.assertThat(actual.getFirst().getQuantity()).isEqualTo(0);
+                        it.assertThat(actual.get(1).getQuantity()).isEqualTo(1);
+                    });
+
+                    verify(soldOutProductService).soldOut("A202307300138");
+                    verify(soldOutProductService, never()).soldOut("A202307300139");
                 }
             }
 
@@ -371,49 +392,56 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                         new Stock("A202307300142", 100, 50),
                         new Stock("A202307300143", 100, 49)
                     );
+
                     saveAll(stocks);
 
                     when(soldOutProductService.soldOut("A202307300142")).thenReturn(
-                        new FindProductResult(
-                            "A202307300142",
-                            PRODUCT_NAME,
-                            ProductStatus.SOLD_OUT,
-                            100,
-                            LocalDateTime.now(),
-                            LocalDateTime.now()
-                        )
+                        TestFixtures.get().giveMeBuilder(FindProductResult.class)
+                            .sample()
                     );
                 }
 
                 @Test
                 @DisplayName("정상적으로 50개씩 재고를 차감하고, 최소 제한 재고수량인 상품은 SoldOut()을 호출한다.")
                 void it() throws InterruptedException {
-                    ExecutorService executorService = Executors.newFixedThreadPool(5);
-                    CountDownLatch latch = new CountDownLatch(threadCount);
+                    ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+                    CountDownLatch startLatch = new CountDownLatch(1);
+                    CountDownLatch endLatch = new CountDownLatch(executeCount);
+                    AtomicInteger successCount = new AtomicInteger();
+                    AtomicInteger failureCount = new AtomicInteger();
 
-                    for (int i = 0; i < threadCount; i++) {
+                    for (int i = 0; i < executeCount; i++) {
                         executorService.submit(() -> {
                                 try {
+                                    startLatch.await();
                                     decreaseStockService.decrease(param);
+                                    successCount.incrementAndGet();
+                                } catch (Exception e) {
+                                    failureCount.incrementAndGet();
                                 } finally {
-                                    latch.countDown();
+                                    endLatch.countDown();
                                 }
                             }
                         );
                     }
 
-                    latch.await();
+                    startLatch.countDown();
+                    endLatch.await();
+                    executorService.shutdown();
 
-                    List<Stock> results = jpaQueryFactory.selectFrom(QStock.stock)
+                    List<Stock> actual = jpaQueryFactory.selectFrom(QStock.stock)
                         .where(QStock.stock.productCode.in(List.of("A202307300142", "A202307300143")))
                         .fetch();
 
-                    assertAll(
-                        () -> assertEquals(50, results.get(0).getQuantity()),
-                        () -> assertEquals(50, results.get(1).getQuantity()),
-                        () -> verify(soldOutProductService, times(1)).soldOut("A202307300142"),
-                        () -> verify(soldOutProductService, times(0)).soldOut("A202307300143")
-                    );
+                    assertSoftly(it -> {
+                        it.assertThat(successCount.get()).isEqualTo(10);
+                        it.assertThat(failureCount.get()).isEqualTo(0);
+                        it.assertThat(actual.getFirst().getQuantity()).isEqualTo(50);
+                        it.assertThat(actual.get(1).getQuantity()).isEqualTo(50);
+                    });
+
+                    verify(soldOutProductService).soldOut("A202307300142");
+                    verify(soldOutProductService, never()).soldOut("A202307300143");
                 }
             }
         }

--- a/src/test/java/com/example/demo/web/v1/stock/DecreaseStockControllerTest.java
+++ b/src/test/java/com/example/demo/web/v1/stock/DecreaseStockControllerTest.java
@@ -1,0 +1,97 @@
+package com.example.demo.web.v1.stock;
+
+import com.example.demo.core.stock.param.DecreaseStockParam;
+import com.example.demo.core.stock.service.DecreaseStockService;
+import com.example.demo.web.v1.stock.request.DecreaseStockRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("DecreaseStockController")
+@WebMvcTest(controllers = DecreaseStockController.class)
+class DecreaseStockControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private DecreaseStockService decreaseStockService;
+
+    @Test
+    @DisplayName("재고 차감 API 호출 시 정상적으로 처리된다")
+    void decreaseStock() throws Exception {
+        // given
+        DecreaseStockRequest.Stock stock1 = new DecreaseStockRequest.Stock("P001", 5);
+        DecreaseStockRequest.Stock stock2 = new DecreaseStockRequest.Stock("P002", 10);
+        DecreaseStockRequest request = new DecreaseStockRequest(Set.of(stock1, stock2));
+
+        // when & then
+        mockMvc.perform(post("/v1/stocks/decrease")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(decreaseStockService).decrease(any(DecreaseStockParam.class));
+    }
+
+    @Test
+    @DisplayName("재고 차감 요청 시 상품 코드가 비어있으면 400 에러를 반환한다")
+    void decreaseStock_withEmptyProductCode_returnsBadRequest() throws Exception {
+        // given
+        DecreaseStockRequest.Stock invalidStock = new DecreaseStockRequest.Stock("", 5);
+        DecreaseStockRequest request = new DecreaseStockRequest(Set.of(invalidStock));
+
+        // when & then
+        mockMvc.perform(post("/v1/stocks/decrease")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.exception").value("MethodArgumentNotValidException"));
+    }
+
+    @Test
+    @DisplayName("재고 차감 요청 시 수량이 0 이하이면 400 에러를 반환한다")
+    void decreaseStock_withInvalidQuantity_returnsBadRequest() throws Exception {
+        // given
+        DecreaseStockRequest.Stock invalidStock = new DecreaseStockRequest.Stock("P001", 0);
+        DecreaseStockRequest request = new DecreaseStockRequest(Set.of(invalidStock));
+
+        // when & then
+        mockMvc.perform(post("/v1/stocks/decrease")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.exception").value("MethodArgumentNotValidException"));
+    }
+
+    @Test
+    @DisplayName("재고 차감 요청 시 상품 목록이 비어있으면 400 에러를 반환한다")
+    void decreaseStock_withEmptyStocks_returnsBadRequest() throws Exception {
+        // given
+        DecreaseStockRequest request = new DecreaseStockRequest(Set.of());
+
+        // when & then
+        mockMvc.perform(post("/v1/stocks/decrease")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.exception").value("MethodArgumentNotValidException"));
+    }
+}


### PR DESCRIPTION
재고차감 코드 리팩토링

- 동시성 검증 테스트 코드 보완
  - as-is 
    - latch를 하나만 사용
  - to-be 
    - startLatch와 endLatch를 선언하여 스레드들의 시작 시점을 동일하게 맞춤
    - AtomicInteger 기반 성공, 실패 횟수 검증 추가
- 재고차감 실패 도메인 익셉션 정의
- dto를 record 타입으로 변환
- stockId 기준으로 동등성을 검증하기 위한 equals(), hasCode() 추가
- 컨트롤러 WebMvcTest 추가
