### PR TITLE
Feature/decrease stock with native query

### DIFF
--- a/src/main/java/com/example/demo/core/stock/service/DecreaseStockNativeQueryService.java
+++ b/src/main/java/com/example/demo/core/stock/service/DecreaseStockNativeQueryService.java
@@ -1,0 +1,39 @@
+package com.example.demo.core.stock.service;
+
+import com.example.demo.core.stock.domain.InvalidStockQuantityException;
+import com.example.demo.core.stock.param.DecreaseStockParam;
+import com.example.demo.infrastructure.persistence.stock.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DecreaseStockNativeQueryService implements DecreaseStockService {
+
+    private final StockRepository stockRepository;
+
+    @Override
+    public void decrease(final DecreaseStockParam param) {
+        param.stocks()
+            .stream()
+            .sorted(Comparator.comparing(DecreaseStockParam.Stock::productCode))
+            .collect(Collectors.toCollection(LinkedHashSet::new))
+            .forEach(it -> {
+                int success = stockRepository.decreaseQuantity(it.productCode(), it.quantity());
+
+                if (success == 0) {
+                    throw new InvalidStockQuantityException();
+                }
+
+                // TODO SOLD OUT 처리 필요
+            });
+    }
+}

--- a/src/main/java/com/example/demo/core/stock/service/DecreaseStockPessimisticLockService.java
+++ b/src/main/java/com/example/demo/core/stock/service/DecreaseStockPessimisticLockService.java
@@ -1,0 +1,44 @@
+package com.example.demo.core.stock.service;
+
+import com.example.demo.core.product.service.SoldOutProductService;
+import com.example.demo.core.stock.domain.Stock;
+import com.example.demo.core.stock.param.DecreaseStockParam;
+import com.example.demo.infrastructure.persistence.stock.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DecreaseStockPessimisticLockService implements DecreaseStockService {
+
+    private final StockRepository stockRepository;
+    private final SoldOutProductService soldOutProductService;
+
+    @Override
+    public void decrease(final DecreaseStockParam param) {
+        param.stocks()
+            .stream()
+            .sorted(Comparator.comparing(DecreaseStockParam.Stock::productCode))
+            .collect(Collectors.toCollection(LinkedHashSet::new))
+            .forEach(item -> {
+                    Stock decreasedStock = stockRepository.findByProductCodeForUpdate(item.productCode())
+                        .orElseThrow()
+                        .decrease(item.quantity());
+
+                    log.info("[Decrease Stock] stockId: {} quantity: {}", decreasedStock.getStockId(), decreasedStock.getQuantity());
+
+                    if (decreasedStock.isLimitQuantity()) {
+                        soldOutProductService.soldOut(item.productCode());
+                    }
+                }
+            );
+    }
+}

--- a/src/main/java/com/example/demo/core/stock/service/DecreaseStockPessimisticLockService.java
+++ b/src/main/java/com/example/demo/core/stock/service/DecreaseStockPessimisticLockService.java
@@ -6,6 +6,7 @@ import com.example.demo.core.stock.param.DecreaseStockParam;
 import com.example.demo.infrastructure.persistence.stock.StockRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +15,7 @@ import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
 
 @Slf4j
+@Primary
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -28,15 +30,15 @@ public class DecreaseStockPessimisticLockService implements DecreaseStockService
             .stream()
             .sorted(Comparator.comparing(DecreaseStockParam.Stock::productCode))
             .collect(Collectors.toCollection(LinkedHashSet::new))
-            .forEach(item -> {
-                    Stock decreasedStock = stockRepository.findByProductCodeForUpdate(item.productCode())
+            .forEach(it -> {
+                    Stock decreasedStock = stockRepository.findByProductCodeForUpdate(it.productCode())
                         .orElseThrow()
-                        .decrease(item.quantity());
+                        .decrease(it.quantity());
 
                     log.info("[Decrease Stock] stockId: {} quantity: {}", decreasedStock.getStockId(), decreasedStock.getQuantity());
 
                     if (decreasedStock.isLimitQuantity()) {
-                        soldOutProductService.soldOut(item.productCode());
+                        soldOutProductService.soldOut(it.productCode());
                     }
                 }
             );

--- a/src/main/java/com/example/demo/core/stock/service/DecreaseStockService.java
+++ b/src/main/java/com/example/demo/core/stock/service/DecreaseStockService.java
@@ -1,43 +1,8 @@
 package com.example.demo.core.stock.service;
 
-import com.example.demo.core.product.service.SoldOutProductService;
-import com.example.demo.core.stock.domain.Stock;
 import com.example.demo.core.stock.param.DecreaseStockParam;
-import com.example.demo.infrastructure.persistence.stock.StockRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Comparator;
-import java.util.LinkedHashSet;
-import java.util.stream.Collectors;
+public interface DecreaseStockService {
 
-@Slf4j
-@Service
-@Transactional
-@RequiredArgsConstructor
-public class DecreaseStockService {
-
-    private final StockRepository stockRepository;
-    private final SoldOutProductService soldOutProductService;
-
-    public void decrease(final DecreaseStockParam param) {
-        param.stocks()
-            .stream()
-            .sorted(Comparator.comparing(DecreaseStockParam.Stock::productCode))
-            .collect(Collectors.toCollection(LinkedHashSet::new))
-            .forEach(item -> {
-                    Stock decreasedStock = stockRepository.findByProductCodeForUpdate(item.productCode())
-                        .orElseThrow()
-                        .decrease(item.quantity());
-
-                    log.info("[Decrease Stock] stockId: {} quantity: {}", decreasedStock.getStockId(), decreasedStock.getQuantity());
-
-                    if (decreasedStock.isLimitQuantity()) {
-                        soldOutProductService.soldOut(item.productCode());
-                    }
-                }
-            );
-    }
+    void decrease(DecreaseStockParam param);
 }

--- a/src/main/java/com/example/demo/infrastructure/persistence/stock/StockRepository.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/stock/StockRepository.java
@@ -4,7 +4,9 @@ import com.example.demo.core.stock.domain.Stock;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -15,4 +17,17 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT s FROM Stock s WHERE s.productCode = :productCode")
     Optional<Stock> findByProductCodeForUpdate(String productCode);
+
+    @Modifying
+    @Query(
+        value =
+            " UPDATE stock SET quantity = (quantity - :quantity) " +
+            " WHERE product_code = :productCode " +
+            " AND quantity >= :quantity ",
+        nativeQuery = true
+    )
+    int decreaseQuantity(
+        @Param("productCode") String productCode,
+        @Param("quantity") long quantity
+    );
 }

--- a/src/main/java/com/example/demo/infrastructure/persistence/stock/StockRepository.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/stock/StockRepository.java
@@ -20,10 +20,11 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
 
     @Modifying
     @Query(
-        value =
-            " UPDATE stock SET quantity = (quantity - :quantity) " +
-            " WHERE product_code = :productCode " +
-            " AND quantity >= :quantity ",
+        value = """
+            UPDATE stock SET quantity = (quantity - :quantity)
+            WHERE product_code = :productCode
+            AND quantity >= :quantity
+            """,
         nativeQuery = true
     )
     int decreaseQuantity(

--- a/src/test/java/com/example/demo/core/stock/service/DecreaseStockNativeQueryServiceTest.java
+++ b/src/test/java/com/example/demo/core/stock/service/DecreaseStockNativeQueryServiceTest.java
@@ -1,0 +1,123 @@
+package com.example.demo.core.stock.service;
+
+import com.example.demo.TestDataInsertSupport;
+import com.example.demo.annotation.IntegrationTest;
+import com.example.demo.core.stock.domain.Stock;
+import com.example.demo.core.stock.param.DecreaseStockParam;
+import com.example.demo.infrastructure.persistence.stock.StockRepository;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@IntegrationTest
+@RequiredArgsConstructor
+@DisplayName("DecreaseStockNativeQueryService")
+class DecreaseStockNativeQueryServiceTest extends TestDataInsertSupport {
+
+    private final StockRepository stockRepository;
+    private final DecreaseStockNativeQueryService sut;
+
+    private final String PRODUCT_CODE = "A202307300138";
+    private final int threads = 5; // 스레드 수
+    private final int executeCount = 10; // 테스트 수행 횟수
+
+    @BeforeEach
+    void setUp() {
+        // 매 테스트마다 초기 재고 세팅
+        stockRepository.deleteAll();
+        save(new Stock(PRODUCT_CODE, 100, 0)); // 초기 재고 100
+    }
+
+    @Test
+    @DisplayName("100개의 재고를 5개씩 동시에 10번 차감하여 남은 재고는 50개이다.")
+    void test1() throws InterruptedException {
+        final ExecutorService executorService = Executors.newFixedThreadPool(threads);
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(executeCount);
+        final AtomicInteger successCount = new AtomicInteger(0);
+        final AtomicInteger failureCount = new AtomicInteger(0);
+
+        final var param = new DecreaseStockParam(Set.of(new DecreaseStockParam.Stock(PRODUCT_CODE, 5L)));
+
+        for (int i = 0; i < executeCount; i++) {
+            executorService.submit(() -> {
+                    try {
+                        startLatch.await();
+                        sut.decrease(param);
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        failureCount.incrementAndGet();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }
+            );
+        }
+
+        startLatch.countDown();
+        endLatch.await();
+        executorService.shutdown();
+
+        // 검증
+        var actual = stockRepository.findByProductCode(PRODUCT_CODE).stream()
+            .findFirst()
+            .orElseThrow();
+
+        assertSoftly(it -> {
+            it.assertThat(successCount.get()).isEqualTo(10);
+            it.assertThat(failureCount.get()).isEqualTo(0);
+            it.assertThat(actual.getQuantity()).isEqualTo(50);
+        });
+    }
+
+    @Test
+    @DisplayName("100개의 재고를 11개씩 동시에 10번 차감했을 때 9번까지 99개를 차감하고, 10번째 차감은 실패하여 남은 재고는 1개이다.")
+    void test2() throws InterruptedException {
+        final ExecutorService executorService = Executors.newFixedThreadPool(threads);
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(executeCount);
+        final AtomicInteger successCount = new AtomicInteger(0);
+        final AtomicInteger failureCount = new AtomicInteger(0);
+
+        final var param = new DecreaseStockParam(Set.of(new DecreaseStockParam.Stock(PRODUCT_CODE, 11L)));
+
+        for (int i = 0; i < executeCount; i++) {
+            executorService.submit(() -> {
+                    try {
+                        startLatch.await();
+                        sut.decrease(param);
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        failureCount.incrementAndGet();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }
+            );
+        }
+
+        startLatch.countDown();
+        endLatch.await();
+        executorService.shutdown();
+
+        // 검증
+        var actual = stockRepository.findByProductCode(PRODUCT_CODE).stream()
+            .findFirst()
+            .orElseThrow();
+
+        assertSoftly(it -> {
+            it.assertThat(successCount.get()).isEqualTo(9);
+            it.assertThat(failureCount.get()).isEqualTo(1);
+            it.assertThat(actual.getQuantity()).isEqualTo(1);
+        });
+    }
+}

--- a/src/test/java/com/example/demo/core/stock/service/DecreaseStockPessimisticLockServiceTest.java
+++ b/src/test/java/com/example/demo/core/stock/service/DecreaseStockPessimisticLockServiceTest.java
@@ -34,11 +34,11 @@ import static org.mockito.Mockito.when;
 
 @IntegrationTest
 @RequiredArgsConstructor
-@DisplayName("DecreaseStockService")
-class DecreaseStockServiceTest extends TestDataInsertSupport {
+@DisplayName("DecreaseStockPessimisticLockService")
+class DecreaseStockPessimisticLockServiceTest extends TestDataInsertSupport {
 
     private final StockRepository stockRepository;
-    private final DecreaseStockService decreaseStockService;
+    private final DecreaseStockPessimisticLockService sut;
 
     @MockitoBean
     SoldOutProductService soldOutProductService;
@@ -84,7 +84,7 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                 @Test
                 @DisplayName("정상적으로 재고를 차감하고, 재고가 모두 소진된 상품은 SoldOut()을 호출한다.")
                 void it() {
-                    decreaseStockService.decrease(param);
+                    sut.decrease(param);
 
                     List<Stock> actual = jpaQueryFactory.selectFrom(QStock.stock)
                         .where(QStock.stock.productCode.in(List.of("A202307300130", "A202307300131")))
@@ -122,7 +122,7 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                 @Test
                 @DisplayName("InvalidStockQuantityException을 던지고, 차감한 재고를 롤백한다.")
                 void it() {
-                    assertThatThrownBy(() -> decreaseStockService.decrease(param))
+                    assertThatThrownBy(() -> sut.decrease(param))
                         .isExactlyInstanceOf(InvalidStockQuantityException.class)
                         .extracting("businessErrorCode")
                         .isEqualTo(INVALID_STOCK_QUANTITY);
@@ -161,7 +161,7 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                 @Test
                 @DisplayName("BusinessException을 던지고, 차감한 재고를 롤백한다.")
                 void it() {
-                    assertThatThrownBy(() -> decreaseStockService.decrease(param))
+                    assertThatThrownBy(() -> sut.decrease(param))
                         .isExactlyInstanceOf(InvalidStockQuantityException.class)
                         .extracting("businessErrorCode")
                         .isEqualTo(INVALID_STOCK_QUANTITY);
@@ -218,7 +218,7 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                         executorService.submit(() -> {
                                 try {
                                     startLatch.await();
-                                    decreaseStockService.decrease(param);
+                                    sut.decrease(param);
                                     successCount.incrementAndGet();
                                 } catch (Exception e) {
                                     failureCount.incrementAndGet();
@@ -278,7 +278,7 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                         executorService.submit(() -> {
                                 try {
                                     startLatch.await();
-                                    decreaseStockService.decrease(param);
+                                    sut.decrease(param);
                                     successCount.incrementAndGet();
                                 } catch (Exception e) {
                                     failureCount.incrementAndGet();
@@ -344,7 +344,7 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                         executorService.submit(() -> {
                                 try {
                                     startLatch.await();
-                                    decreaseStockService.decrease(param);
+                                    sut.decrease(param);
                                     successCount.incrementAndGet();
                                 } catch (Exception e) {
                                     failureCount.incrementAndGet();
@@ -414,7 +414,7 @@ class DecreaseStockServiceTest extends TestDataInsertSupport {
                         executorService.submit(() -> {
                                 try {
                                     startLatch.await();
-                                    decreaseStockService.decrease(param);
+                                    sut.decrease(param);
                                     successCount.incrementAndGet();
                                 } catch (Exception e) {
                                     failureCount.incrementAndGet();

--- a/src/test/java/com/example/demo/core/stock/service/DecreaseStockPessimisticLockServiceTest.java
+++ b/src/test/java/com/example/demo/core/stock/service/DecreaseStockPessimisticLockServiceTest.java
@@ -211,8 +211,8 @@ class DecreaseStockPessimisticLockServiceTest extends TestDataInsertSupport {
                     ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
                     CountDownLatch startLatch = new CountDownLatch(1);
                     CountDownLatch endLatch = new CountDownLatch(executeCount);
-                    AtomicInteger successCount = new AtomicInteger();
-                    AtomicInteger failureCount = new AtomicInteger();
+                    AtomicInteger successCount = new AtomicInteger(0);
+                    AtomicInteger failureCount = new AtomicInteger(0);
 
                     for (int i = 0; i < executeCount; i++) {
                         executorService.submit(() -> {
@@ -271,8 +271,8 @@ class DecreaseStockPessimisticLockServiceTest extends TestDataInsertSupport {
                     ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
                     CountDownLatch startLatch = new CountDownLatch(1);
                     CountDownLatch endLatch = new CountDownLatch(executeCount);
-                    AtomicInteger successCount = new AtomicInteger();
-                    AtomicInteger failureCount = new AtomicInteger();
+                    AtomicInteger successCount = new AtomicInteger(0);
+                    AtomicInteger failureCount = new AtomicInteger(0);
 
                     for (int i = 0; i < executeCount; i++) {
                         executorService.submit(() -> {
@@ -337,8 +337,8 @@ class DecreaseStockPessimisticLockServiceTest extends TestDataInsertSupport {
                     ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
                     CountDownLatch startLatch = new CountDownLatch(1);
                     CountDownLatch endLatch = new CountDownLatch(executeCount);
-                    AtomicInteger successCount = new AtomicInteger();
-                    AtomicInteger failureCount = new AtomicInteger();
+                    AtomicInteger successCount = new AtomicInteger(0);
+                    AtomicInteger failureCount = new AtomicInteger(0);
 
                     for (int i = 0; i < executeCount; i++) {
                         executorService.submit(() -> {
@@ -407,8 +407,8 @@ class DecreaseStockPessimisticLockServiceTest extends TestDataInsertSupport {
                     ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
                     CountDownLatch startLatch = new CountDownLatch(1);
                     CountDownLatch endLatch = new CountDownLatch(executeCount);
-                    AtomicInteger successCount = new AtomicInteger();
-                    AtomicInteger failureCount = new AtomicInteger();
+                    AtomicInteger successCount = new AtomicInteger(0);
+                    AtomicInteger failureCount = new AtomicInteger(0);
 
                     for (int i = 0; i < executeCount; i++) {
                         executorService.submit(() -> {

--- a/src/test/java/com/example/demo/core/stock/service/IncreaseStockServiceWithDecreaseTest.java
+++ b/src/test/java/com/example/demo/core/stock/service/IncreaseStockServiceWithDecreaseTest.java
@@ -32,7 +32,7 @@ class IncreaseStockServiceWithDecreaseTest extends TestDataInsertSupport {
     IncreaseStockService increaseStockService;
 
     @Autowired
-    DecreaseStockService decreaseStockService;
+    DecreaseStockPessimisticLockService decreaseStockPessimisticLockService;
 
     @Autowired
     StockRepository stockRepository;
@@ -90,7 +90,7 @@ class IncreaseStockServiceWithDecreaseTest extends TestDataInsertSupport {
                     executorService.submit(() -> {
                             try {
                                 increaseStockService.increase(increaseStockParam);
-                                decreaseStockService.decrease(decreaseStockParam);
+                                decreaseStockPessimisticLockService.decrease(decreaseStockParam);
                             } finally {
                                 latch.countDown();
                             }


### PR DESCRIPTION
native query 방식 재고 차감 구현

기존에는 낙관적락으로 데이터 조회 시 락을 잡고, 어플리케이션에서 재고를 차감하여 동시성 보장

native query 방식은 UPDATE 쿼리문으로 동시성을 보장함
```
UPDATE stock SET quantity = (quantity - :quantity)
WHERE product_code = :productCode
AND quantity >= :quantity
```

**gpt 답변**
> UPDATE/DELETE/잠금 조회는 검색한 인덱스 레코드에 “레코드 락(필요 시 넥스트키 락)”을 건다. 즉, InnoDB는 인덱스를 스캔하면서 해당 레코드들에 공유/배타 락을 설정합니다. 그래서 같은 행을 다른 트랜잭션이 갱신하려 하면 충돌이 납니다.
> 충돌하는 락은 큐에 적재되어 “대기”합니다. 어떤 트랜잭션이 행을 갱신(또는 SELECT ... FOR UPDATE)해 락을 잡고 있으면, 두 번째 트랜잭션의 락 요청은 큐에 들어가며 선행 트랜잭션이 끝날 때까지 기다립니다.
> InnoDB는 행 수준 락으로 동시 쓰기를 안전하게 지원합니다(다중 사용자/OLTP에 적합). 즉, 한 시점에 같은 행은 한 트랜잭션만 갱신할 수 있습니다.
> UPDATE는 WHERE 조건을 만족하는 행만 수정합니다. 선행 트랜잭션이 커밋되어 수량이 줄어 조건을 더 이상 만족하지 않으면, 후행 트랜잭션은 “영향 행 0”으로 끝납니다. 
>
> SELECT에서는 팬텀 리드 문제를 MVCC로 제어합니다.
> 하지만 UPDATE/DELETE/INSERT는 MVCC가 아니라 잠금 기반으로 처리되기 때문에 격리 수준에 관계없이 원자성이 보장됩니다.
>
> https://dev.mysql.com/doc/refman/8.4/en/internal-locking.html
> https://dev.mysql.com/doc/refman/8.4/en/innodb-locks-set.html
> https://dev.mysql.com/doc/refman/8.4/en/innodb-information-schema-understanding-innodb-locking.html


**오해한 부분**
Mysql 기본 격리 수준이 `REPEATABLE READ`이고, 같은 트랜잭션 안에서 같은 SELECT를 여러 번 실행해도 항상 동일한 스냅샷 결과를 돌려주기 때문에 `SET quantity = (quantity - :quantity)` 이 구문 수행 될 때 데이터를 덮어씌울 줄 알았음

예를 들어 
1. A 트랜잭션에서 quantity가 10
2. B 트랜잭션에서 quantitiy 10을 5로 업데이트
3. A 트랜잭션에서 quantity를 1을 차감한다고 했을 때 4(5 - 1)가 아니라 9(10 - 1)로 될 것으로 생각했음

재밌는건 팀원 모두 같은 오해를 했고, 그 때 당시 gpt에 질의했을 때도 동일한(잘못된) 답변을 했다는 점