### PR TITLE
Feature/virtual thread

### DIFF
--- a/src/main/java/com/example/demo/config/async/DomainEventAsyncConfig.java
+++ b/src/main/java/com/example/demo/config/async/DomainEventAsyncConfig.java
@@ -1,7 +1,9 @@
 package com.example.demo.config.async;
 
+import org.springframework.boot.task.SimpleAsyncTaskExecutorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
@@ -9,6 +11,14 @@ import java.util.concurrent.Executor;
 @Configuration
 public class DomainEventAsyncConfig {
 
+    // application.yml에 spring.threads.virtual.enabled: true 버츄얼 스레드가 활성화 되있다면, @Async 선언 시 기본적으로 버츄얼 스레드를 사용함
+    // @Primary를 선언하지 않아도 메소드명이 taskExecutor라면 기본 빈으로 등록 됨
+    @Bean
+    public SimpleAsyncTaskExecutor taskExecutor(SimpleAsyncTaskExecutorBuilder builder) {
+        return builder.build();
+    }
+
+    // 플랫폼 스레드용 Bean 정의, @Async("domainEventAsyncExecutor")로 선언하면 플랫폼 스레드를 사용함
     @Bean("domainEventAsyncExecutor")
     public Executor domainEventAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();

--- a/src/main/java/com/example/demo/web/v1/virtualthread/VirtualThreadController.java
+++ b/src/main/java/com/example/demo/web/v1/virtualthread/VirtualThreadController.java
@@ -1,0 +1,25 @@
+package com.example.demo.web.v1.virtualthread;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class VirtualThreadController {
+
+    private final AtomicLong counter = new AtomicLong();
+
+    @GetMapping("/sleep")
+    public void sleep() throws InterruptedException {
+        // 버츄얼 스레드를 사용했을 때 부하가 없다면 똑같은 플랫폼 스레드를 사용함
+        // 하지만, 부하가 클 경우 1)과 2) 로그를 찍는 플랫폼 스레드가 달라질 수 있음
+        log.info("1) counter: {}, thread: {}", counter.incrementAndGet(), Thread.currentThread());
+        Thread.sleep(5000);
+        log.info("2) thread: {}", Thread.currentThread());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,9 @@ spring:
       api-key: "OPENAI_API_KEY"
       embedding.options.model: "text-embedding-3-small"
     anthropic.api-key: "ANTHROPIC_API_KEY"
+  threads:
+    virtual:
+      enabled: true # 버츄얼 스레드 활성화
 
 management:
   tracing:

--- a/src/test/java/com/example/etc/virtualthread/JavaForkJoinPoolTest.java
+++ b/src/test/java/com/example/etc/virtualthread/JavaForkJoinPoolTest.java
@@ -1,0 +1,23 @@
+package com.example.etc.virtualthread;
+
+import java.util.List;
+import java.util.Optional;
+
+public class JavaForkJoinPoolTest {
+
+    public static void main(String[] args) {
+        List<Integer> list = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        // 별도의 스레드 풀을 선언하지 않고, parallelStream()으로 병렬처리를 하면 데몬 스레드로 ForkJoinPool을 생성함
+//        i: 8 , thread: Thread[#26,ForkJoinPool.commonPool-worker-7,5,main] , daemon: true
+//        i: 7 , thread: Thread[#1,main,5,main] , daemon: false
+        Optional<Integer> op = list.parallelStream()
+            .filter(integer -> {
+                System.out.println("i: " + integer + " , thread: " + Thread.currentThread() + " , daemon: " + Thread.currentThread().isDaemon());
+                return integer % 2 == 0;
+            })
+            .findAny();
+
+        System.out.println(op.get());
+    }
+}

--- a/src/test/java/com/example/etc/virtualthread/JavaSingleThreadTest.java
+++ b/src/test/java/com/example/etc/virtualthread/JavaSingleThreadTest.java
@@ -1,0 +1,41 @@
+package com.example.etc.virtualthread;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JavaSingleThreadTest {
+
+    private static final Runnable runnable = new Runnable() {
+        @Override
+        public void run() {
+            log.info("1) run. thread: {}, class: {}", Thread.currentThread(), Thread.currentThread().getClass());
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            log.info("2) run. thread: {}", Thread.currentThread());
+        }
+    };
+
+    public static void main(String[] args) throws InterruptedException {
+
+        // Thread
+//        21:21:35.080 [Thread-0] INFO com.example.etc.virtualthread.JavaThreadTest -- 1) run. thread: Thread[#20,Thread-0,5,main]
+//        21:21:36.083 [Thread-0] INFO com.example.etc.virtualthread.JavaThreadTest -- 2) run. thread: Thread[#20,Thread-0,5,main]
+        Thread thread = new Thread(runnable);
+        thread.start();
+
+        // Thread with Demon
+        Thread thread1 = new Thread(runnable);
+        thread1.setDaemon(true);
+        thread1.start();
+        thread1.join();
+
+        // Virtual Thread
+//        21:26:31.500 [myVirtual] INFO com.example.etc.virtualthread.JavaThreadTest -- 1) run. thread: VirtualThread[#20,myVirtual]/runnable@ForkJoinPool-1-worker-1, class: class java.lang.VirtualThread
+//        21:26:32.506 [myVirtual] INFO com.example.etc.virtualthread.JavaThreadTest -- 2) run. thread: VirtualThread[#20,myVirtual]/runnable@ForkJoinPool-1-worker-1
+        Thread virtualThread = Thread.ofVirtual().name("myVirtual").start(runnable);
+        virtualThread.join(); // ForkJoinPool은 데몬 스레드로 동작함. 데몬 스레드만 있으면 애플리케이션이 종료 됨. 일반 스레드가 있어야 하고, .join()이 있어야 기다려줌
+    }
+}

--- a/src/test/java/com/example/etc/virtualthread/JavaThreadPoolTest.java
+++ b/src/test/java/com/example/etc/virtualthread/JavaThreadPoolTest.java
@@ -1,0 +1,66 @@
+package com.example.etc.virtualthread;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+@Slf4j
+public class JavaThreadPoolTest {
+
+    private static final Runnable runnable = new Runnable() {
+        @Override
+        public void run() {
+            log.info("1) run. thread: {}, class: {}", Thread.currentThread(), Thread.currentThread().getClass());
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            log.info("2) run. thread: {}", Thread.currentThread());
+        }
+    };
+
+    public static void main(String[] args) {
+        log.info("1) main. thread: {}", Thread.currentThread());
+
+        // 일반 스레드 풀
+        try (ExecutorService executorService = Executors.newFixedThreadPool(10)) {
+            for (int i = 0; i < 10; i++) {
+                executorService.submit(runnable);
+            }
+        }
+
+        // 버추얼 스레드 풀
+        ThreadFactory factory = Thread.ofVirtual().name("myVirtual-", 0).factory();
+        try (ExecutorService executorService = Executors.newThreadPerTaskExecutor(factory)) {
+            for (int i = 0; i < 10; i++) {
+                executorService.submit(runnable);
+            }
+        }
+
+
+        log.info("2) main. thread: {}", Thread.currentThread());
+    }
+
+    // newFixedThreadPool(1)로 되어 있어서 스레드 풀이지만 버추얼 스레드를 1개만 사용함
+    private static void antiPattern1() {
+        ThreadFactory factory = Thread.ofVirtual().name("myVirtual-", 0).factory();
+        try (ExecutorService executorService = Executors.newFixedThreadPool(1, factory)) {
+            for (int i = 0; i < 10; i++) {
+                executorService.submit(runnable);
+            }
+        }
+    }
+
+    // 버추얼 스레드로 선언했으나 newSingleThreadExecutor()라서 버추얼 스레드를 1개만 사용함
+    private static void antiPattern2() {
+        ThreadFactory factory = Thread.ofVirtual().name("myVirtual-", 0).factory();
+        try (ExecutorService executorService = Executors.newSingleThreadExecutor(factory)) {
+            for (int i = 0; i < 10; i++) {
+                executorService.submit(runnable);
+            }
+        }
+    }
+}

--- a/src/test/java/com/example/etc/virtualthread/Pinning.java
+++ b/src/test/java/com/example/etc/virtualthread/Pinning.java
@@ -1,0 +1,73 @@
+package com.example.etc.virtualthread;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Slf4j
+public class Pinning {
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    // -Djdk.tracePinnedThreads=full  or -Djdk.tracePinnedThreads=short 를 통해 프로젝트의 코드와 서드파티 라이브러리의 synchronized 선언을 찾을 수 있음
+    private final Runnable runnable = new Runnable() {
+        @Override
+        public void run() {
+
+            // synchronized 또는 네이티브 메소드를 실행 중에 IO 블럭이 발생했을 때 버츄얼 스레드가 플랫폼(Java) 스레드에 언마운트 되지 않음
+            // 버츄얼 스레드는 IO 블럭이 발생하면 플랫폼 스레드 언마운트하고, 다른 버추얼 스레드가 플랫폼 스레드를 마운트하여 교대로 사용함
+            synchronized (this) {
+                log.info("1) run. thread: {}", Thread.currentThread());
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                log.info("2) run. thread: {}", Thread.currentThread());
+            }
+
+            // ReentrantLock을 사용하면, 성능저하 없이 버츄얼 스레드 + synchronized 동작을 대체할 수 있음
+            lock.lock();
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } finally {
+                lock.unlock();
+            }
+        }
+    };
+
+
+    public static void main(String[] args) {
+        long startTime = System.currentTimeMillis();
+        log.info("1) main. thread: {}", Thread.currentThread());
+
+//        platform();
+        virtual();
+
+        log.info("2) main. time: {} , thread: {}", System.currentTimeMillis() - startTime, Thread.currentThread());
+    }
+
+    private static void virtual() {
+        ThreadFactory factory = Thread.ofVirtual().name("myVirtual-", 0).factory();
+        try (ExecutorService executorService = Executors.newThreadPerTaskExecutor(factory)) {
+            for (int i = 0; i < 20; i++) {
+                Pinning pinning = new Pinning();
+                executorService.submit(pinning.runnable);
+            }
+        }
+    }
+
+    private static void platform() {
+        try (ExecutorService executorService = Executors.newFixedThreadPool(20)) {
+            for (int i = 0; i < 20; i++) {
+                Pinning pinning = new Pinning();
+                executorService.submit(pinning.runnable);
+            }
+        }
+    }
+}


### PR DESCRIPTION
인프런 1시간만에 끝내는 virtual thread in spring boot
https://inf.run/tWAck

버츄얼 스레드를 사용한다고 무조건 좋아지는건 아님
수행하는 로직에서 IO 블락이 얼마나 존재하는지, CPU(계산)를 얼마나 사용하는지에 따라 버츄얼 스레드와 플랫폼 스레드간 성능 차이는 달라짐

IO 블락이 많은 작업은 버츄얼 스레드가 좋음
CPU 계산이 많은 작업은 플랫폼 스레드가 좋음. 버츄얼 스레드가 플랫폼 스레드를 마운트/언마운트하는 과정에서 오버헤드가 발생할 수 있음

스프링부트에서 버츄얼 스레드를 활성화하면 톰캣, `@Async`, `@Scheduled`가 버츄얼 스레드로 동작하기 때문에 플랫폼 스레드를 사용할 수 있도록 별도 Bean 정의 가능

서드파티 라이브러리에 synchronized가 있는지 확인해야함
버츄얼 스레드 + synchronized 조합은 성능 저하가 심함