### PR TITLE
Feature/jpa with stream

### DIFF
--- a/src/main/java/com/example/demo/infrastructure/persistence/stock/StockRepository.java
+++ b/src/main/java/com/example/demo/infrastructure/persistence/stock/StockRepository.java
@@ -9,10 +9,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
 
     Optional<Stock> findByProductCode(String productCode);
+
+    @Query("SELECT s FROM Stock s")
+    Stream<Stock> streamAll();
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT s FROM Stock s WHERE s.productCode = :productCode")

--- a/src/test/java/com/example/demo/infrastructure/persistence/stock/StockRepositoryTest.java
+++ b/src/test/java/com/example/demo/infrastructure/persistence/stock/StockRepositoryTest.java
@@ -1,0 +1,90 @@
+package com.example.demo.infrastructure.persistence.stock;
+
+import com.example.demo.TestFixtures;
+import com.example.demo.annotation.RepositoryTest;
+import com.example.demo.core.stock.domain.Stock;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+@DisplayName("StockRepository")
+class StockRepositoryTest {
+
+    @Autowired
+    private StockRepository sut;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        sut.deleteAll();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        var expected = IntStream.rangeClosed(1, 10_000)
+            .mapToObj(String::valueOf)
+            .collect(Collectors.toList())
+            .iterator();
+
+        var stocks = TestFixtures.get().giveMeBuilder(Stock.class)
+            .setNull("stockId")
+            .setLazy("productCode", expected::next)
+            .sampleList(10_000);
+
+        sut.saveAll(stocks);
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("streamAll()은 데이터를 한 번에 한 건씩 가져온다.")
+    void test1() {
+        var runtime = Runtime.getRuntime();
+        var memoryBefore = runtime.totalMemory() - runtime.freeMemory();
+
+        long actual = 0;
+        try (var stream = sut.streamAll()) {
+            actual = stream.peek(it -> {
+                // 중간마다 메모리 사용량 확인
+                if (it.getStockId() % 1_000 == 0) {
+                    var current = runtime.totalMemory() - runtime.freeMemory();
+                    System.out.println("Processed: " + it.getStockId() + ", Memory used: " + (current - memoryBefore) / 1024 / 1024 + "MB");
+                }
+            }).count(); // 실제 데이터를 한 줄씩 읽음
+        }
+
+        var memoryAfter = runtime.totalMemory() - runtime.freeMemory();
+
+        System.out.println("총 처리 건수: " + actual);
+        System.out.println("메모리 사용 증가량: " + (memoryAfter - memoryBefore) / 1024 / 1024 + "MB");
+
+        assertThat(actual).isEqualTo(10_000);
+    }
+
+    @Test
+    @DisplayName("findAll()은 데이터를 한 번에 모두 가져온다.")
+    void test2() {
+        var runtime = Runtime.getRuntime();
+        var memoryBefore = runtime.totalMemory() - runtime.freeMemory();
+
+        var actual = sut.findAll();
+
+        var memoryAfter = runtime.totalMemory() - runtime.freeMemory();
+
+        System.out.println("findAll memory usage: " + (memoryAfter - memoryBefore) / 1024 / 1024 + "MB");
+
+        assertThat(actual).hasSize(10_000);
+    }
+}


### PR DESCRIPTION
Jpa에서 Eloquent ORM의 [Cursors()](https://laravel.com/docs/12.x/eloquent#cursors) 와 동일한 방식으로 수행할 수 없는지 시도해본 PR

Eloquent ORM의 Cursors()를 사용하면 대용량의 데이터를 한 건씩 DBMS로부터 가져와서 처리 후 메모리에서 해제 됨
OOM으로부터 안전함

리턴 타입을 Stream으로 하면 1건씩 데이터를 가져와서 처리함
아래와 같이 메모리가 점점 증가하는 것 확인
```
Processed: 1000, Memory used: 2MB
Processed: 2000, Memory used: 3MB
Processed: 3000, Memory used: 4MB
Processed: 4000, Memory used: 6MB
Processed: 5000, Memory used: 7MB
Processed: 6000, Memory used: 8MB
Processed: 7000, Memory used: 9MB
Processed: 8000, Memory used: 10MB
Processed: 9000, Memory used: 11MB
Processed: 10000, Memory used: 12MB
```
문제는 결국 메모리에 모두 할당되어서 OOM 발생 가능성이 존재함


GPT: Eloquent ORM의 Cursors()를 Java/Spring 환경에서 구현할 수 있는 방안
JDBC 방식은 쿼리문 유지보수가 어려워보임
JpaCursorItemReader는 Spring Batch 의존성이 필요함

방식 | ORM 유지 | 메모리 효율 | 실제 커서 사용 | 실무 적합도 | 비고
-- | -- | -- | -- | -- | --
JDBC + ResultSet | ❌ | ⭐⭐⭐⭐⭐ | ✅ | ⭐⭐⭐⭐⭐ | Eloquent cursor() 완전 동일
Hibernate ScrollableResults | ✅ | ⭐⭐⭐⭐☆ | ✅ | ⭐⭐⭐⭐☆ | JPA 내부 커서
Spring Batch JpaCursorItemReader | ✅ | ⭐⭐⭐⭐☆ | ✅ | ⭐⭐⭐⭐☆ | 배치/대량 처리용
JdbcTemplate RowCallbackHandler | ❌ | ⭐⭐⭐⭐⭐ | ✅ | ⭐⭐⭐⭐☆ | 간단한 커서 처리용
Spring Data stream() | ✅ | ⭐ | ❌ | ⭐ | 메모리 절감 거의 없음